### PR TITLE
use html entities for single quotes in translations

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-msgid "Let's go!"
+msgid "Let&#x27;s go!"
 msgstr ""
 
 msgid "Welcome on {{ instance_name }}"
@@ -78,7 +78,7 @@ msgid_plural "{{ count }} likes"
 msgstr[0] "One follower"
 msgstr[1] "{{ count }} followers"
 
-msgid "I don't like this anymore"
+msgid "I don&#x27;t like this anymore"
 msgstr ""
 
 msgid "Add yours"
@@ -89,7 +89,7 @@ msgid_plural "{{ count }} reshares"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "I don't want to reshare this anymore"
+msgid "I don&#x27;t want to reshare this anymore"
 msgstr ""
 
 msgid "Reshare"
@@ -131,7 +131,7 @@ msgstr ""
 msgid "Your Blogs"
 msgstr ""
 
-msgid "You don't have any blog yet. Create your own, or ask to join one."
+msgid "You don&#x27;t have any blog yet. Create your own, or ask to join one."
 msgstr ""
 
 msgid "Start a new blog"
@@ -269,7 +269,7 @@ msgstr ""
 msgid "{{ data }} commented your article"
 msgstr ""
 
-msgid "We couldn't find this page."
+msgid "We couldn&#x27;t find this page."
 msgstr ""
 
 msgid "The link that led you here may be broken."

--- a/po/fr.po
+++ b/po/fr.po
@@ -59,7 +59,7 @@ msgstr "Configurez votre instance"
 msgid "Name"
 msgstr "Nom"
 
-msgid "Let's go!"
+msgid "Let&#x27;s go!"
 msgstr "C'est parti !"
 
 msgid "Welcome on {{ instance_name }}"
@@ -79,7 +79,7 @@ msgid_plural "{{ count }} likes"
 msgstr[0] "{{ count }} personne aime cet article"
 msgstr[1] "{{ count }} personnes aiment cet article"
 
-msgid "I don't like this anymore"
+msgid "I don&#x27;t like this anymore"
 msgstr "Je n'aime plus"
 
 msgid "Add yours"
@@ -90,7 +90,7 @@ msgid_plural "{{ count }} reshares"
 msgstr[0] "{{ count }} repartage"
 msgstr[1] "{{ count }} repartages"
 
-msgid "I don't want to reshare this anymore"
+msgid "I don&#x27;t want to reshare this anymore"
 msgstr "Je ne veux plus repartager"
 
 msgid "Reshare"
@@ -132,7 +132,7 @@ msgstr "Votre tableau de bord"
 msgid "Your Blogs"
 msgstr "Vos blogs"
 
-msgid "You don't have any blog yet. Create your own, or ask to join one."
+msgid "You don&#x27;t have any blog yet. Create your own, or ask to join one."
 msgstr ""
 "Vous n'avez pas encore de blog. Créez le votre, ou demandez à en rejoindre "
 "un."
@@ -253,30 +253,29 @@ msgstr "Vous devez vous connecter pour suivre quelqu'un"
 msgid "You need to be logged in order to edit your profile"
 msgstr "Vous devez vous connecter pour modifier votre profil"
 
-#, fuzzy
 msgid "By {{ link_1 }}{{ link_2 }}{{ link_3 }}{{ name }}{{ link_4 }}"
-msgstr "Écrit par {{ link_1 }}{{ url }}{{ link_2 }}{{ name }}{{ link_3 }}"
+msgstr "De {{ link_1 }}{{ link_2 }}{{ link_3 }}{{ name }}{{ link_4 }}"
 
 msgid "{{ data }} reshared your article"
-msgstr ""
+msgstr "{{ data }} a repartagé votre article"
 
 msgid "{{ data }} started following you"
-msgstr ""
+msgstr "{{ data }} vous suit"
 
 msgid "{{ data }} liked your article"
-msgstr ""
+msgstr "{{ data }} a aimé votre article"
 
 msgid "{{ data }} commented your article"
-msgstr ""
+msgstr "{{ data }} a commenté votre article"
 
-msgid "We couldn't find this page."
-msgstr ""
+msgid "We couldn&#x27;t find this page."
+msgstr "Page introuvable."
 
 msgid "The link that led you here may be broken."
-msgstr ""
+msgstr "Le lien que vous avez suivi est cassé."
 
 msgid "You are not authorized."
-msgstr ""
+msgstr "Vous n'avez pas les droits."
 
 msgid "You are not author in this blog."
-msgstr ""
+msgstr "Vous n'êtes pas auteur dans ce blog."

--- a/po/pl.po
+++ b/po/pl.po
@@ -60,7 +60,7 @@ msgstr "Skonfiguruj swoją instancję"
 msgid "Name"
 msgstr "Nazwa"
 
-msgid "Let's go!"
+msgid "Let&#x27;s go!"
 msgstr "Przejdźmy dalej!"
 
 msgid "Welcome on {{ instance_name }}"
@@ -81,7 +81,7 @@ msgstr[0] "Jedno polubienie"
 msgstr[1] "{{ count }} polubienia"
 msgstr[2] "{{ count }} polubień"
 
-msgid "I don't like this anymore"
+msgid "I don&#x27;t like this anymore"
 msgstr "Już tego nie lubię"
 
 msgid "Add yours"
@@ -93,7 +93,7 @@ msgstr[0] "Jedno udostępnienie"
 msgstr[1] "{{ count }} udostępnienia"
 msgstr[2] "{{ count }} udostępnień"
 
-msgid "I don't want to reshare this anymore"
+msgid "I don&#x27;t want to reshare this anymore"
 msgstr "Cofnij udostępnienie"
 
 msgid "Reshare"
@@ -135,7 +135,7 @@ msgstr "Twój panel"
 msgid "Your Blogs"
 msgstr "Twoje blogi"
 
-msgid "You don't have any blog yet. Create your own, or ask to join one."
+msgid "You don&#x27;t have any blog yet. Create your own, or ask to join one."
 msgstr ""
 "Nie posiadasz żadnego bloga. Utwórz własny, lub poproś o dołączanie do "
 "istniejącego."
@@ -273,7 +273,7 @@ msgstr "{{ data }} polubił Twój artykuł"
 msgid "{{ data }} commented your article"
 msgstr "{{ data }} skomentował Twój artykuł"
 
-msgid "We couldn't find this page."
+msgid "We couldn&#x27;t find this page."
 msgstr "Nie udało się odnaleźć tej strony."
 
 msgid "The link that led you here may be broken."

--- a/po/plume.pot
+++ b/po/plume.pot
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-msgid "Let's go!"
+msgid "Let&#x27;s go!"
 msgstr ""
 
 msgid "Welcome on {{ instance_name }}"
@@ -77,7 +77,7 @@ msgid_plural "{{ count }} likes"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "I don't like this anymore"
+msgid "I don&#x27;t like this anymore"
 msgstr ""
 
 msgid "Add yours"
@@ -88,7 +88,7 @@ msgid_plural "{{ count }} reshares"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "I don't want to reshare this anymore"
+msgid "I don&#x27;t want to reshare this anymore"
 msgstr ""
 
 msgid "Reshare"
@@ -130,7 +130,7 @@ msgstr ""
 msgid "Your Blogs"
 msgstr ""
 
-msgid "You don't have any blog yet. Create your own, or ask to join one."
+msgid "You don&#x27;t have any blog yet. Create your own, or ask to join one."
 msgstr ""
 
 msgid "Start a new blog"
@@ -264,7 +264,7 @@ msgstr ""
 msgid "{{ data }} commented your article"
 msgstr ""
 
-msgid "We couldn't find this page."
+msgid "We couldn&#x27;t find this page."
 msgstr ""
 
 msgid "The link that led you here may be broken."


### PR DESCRIPTION
The gettext translation was broken if the original string contain a single quote (like in "Let's go") because tera template engine escape this char in entity "\&#x27;", so we need this entity in the original string for matching the translation.
I've also updated the french translation in the mean time ;)
