### PR TITLE
fix(css): Add back outline

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -19,7 +19,6 @@
  a, a:visited {
  	color: #7765E3;
  	text-decoration: none;
- 	outline: none;
  }
 
  small {


### PR DESCRIPTION
Removing outline without adding other indicators for focused content is an accessibility violation (try using Tab to navigate on the page - you can't tell where the focus is).

http://www.outlinenone.com/