### PR TITLE
Verify activity's signature

### DIFF
--- a/plume-common/src/activity_pub/mod.rs
+++ b/plume-common/src/activity_pub/mod.rs
@@ -104,11 +104,12 @@ pub fn broadcast<S: sign::Signer, A: Activity, T: inbox::WithInbox + Actor>(send
 
     for inbox in boxes {
         // TODO: run it in Sidekiq or something like that
+        let mut headers = request::headers();
+        headers.set(request::digest(signed.to_string()));
         let res = Client::new()
             .post(&inbox[..])
-            .headers(request::headers())
-            .header(request::signature(sender, request::headers()))
-            .header(request::digest(signed.to_string()))
+            .headers(headers.clone())
+            .header(request::signature(sender, headers))
             .body(signed.to_string())
             .send();
         match res {

--- a/plume-common/src/activity_pub/mod.rs
+++ b/plume-common/src/activity_pub/mod.rs
@@ -128,6 +128,15 @@ pub enum SignatureValidity {
     Absent,
 }
 
+impl SignatureValidity {
+    pub fn is_secure(&self) -> bool {
+        match self {
+            SignatureValidity::Valid => true,
+            _ => false,
+        }
+    }
+}
+
 pub fn verify_http_headers<S: sign::Signer+::std::fmt::Debug>(sender: &S, all_headers: HeaderMap, data: String) -> SignatureValidity{
     if let Some(sig_header) = all_headers.get_one("Signature") {
         let mut _key_id = None;

--- a/plume-common/src/activity_pub/mod.rs
+++ b/plume-common/src/activity_pub/mod.rs
@@ -1,9 +1,10 @@
 use activitypub::{Activity, Actor, Object, Link};
 use array_tool::vec::Uniq;
+use base64;
 use reqwest::Client;
 use rocket::{
     Outcome,
-    http::Status,
+    http::{Status,HeaderMap},
     response::{Response, Responder},
     request::{FromRequest, Request}
 };
@@ -105,7 +106,7 @@ pub fn broadcast<S: sign::Signer, A: Activity, T: inbox::WithInbox + Actor>(send
     for inbox in boxes {
         // TODO: run it in Sidekiq or something like that
         let mut headers = request::headers();
-        headers.set(request::digest(signed.to_string()));
+        headers.set(request::Digest::digest(signed.to_string()));
         let res = Client::new()
             .post(&inbox[..])
             .headers(headers.clone())
@@ -116,6 +117,59 @@ pub fn broadcast<S: sign::Signer, A: Activity, T: inbox::WithInbox + Actor>(send
             Ok(mut r) => println!("Successfully sent activity to inbox ({})\n\n{:?}", inbox, r.text().unwrap()),
             Err(e) => println!("Error while sending to inbox ({:?})", e)
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum SignatureValidity {
+    Invalid,
+    ValidNoDigest,
+    Valid,
+    Absent,
+}
+
+pub fn verify_http_headers<S: sign::Signer+::std::fmt::Debug>(sender: &S, all_headers: HeaderMap, data: String) -> SignatureValidity{
+    if let Some(sig_header) = all_headers.get_one("Signature") {
+        let mut _key_id = None;
+        let mut _algorithm = None;
+        let mut headers = None;
+        let mut signature = None;
+        for part in sig_header.split(',') {
+            match part {
+                part if part.starts_with("keyId=") => _key_id = Some(&part[7..part.len()-1]),
+                part if part.starts_with("algorithm=") => _algorithm = Some(&part[11..part.len()-1]),
+                part if part.starts_with("headers=") => headers = Some(&part[9..part.len()-1]),
+                part if part.starts_with("signature=") => signature = Some(&part[11..part.len()-1]),
+                _ => {},
+            }
+        }
+        if signature.is_some() && headers.is_some() {
+            let headers = headers.unwrap().split_whitespace().collect::<Vec<_>>();
+            let signature = signature.unwrap();
+            let h = headers.iter()
+                .map(|header| (header,all_headers.get_one(header)))
+                .map(|(header, value)| format!("{}: {}", header.to_lowercase(), value.unwrap_or("")))
+                .collect::<Vec<_>>().join("\n");
+            if sender.verify(h, base64::decode(signature).unwrap_or(Vec::new())) {
+                if headers.contains(&"digest") {
+                    let digest = all_headers.get_one("digest").unwrap_or("");
+                    let digest = request::Digest::from_header(digest);
+                    if digest.map(|d| d.verify(data)).unwrap_or(false) {
+                        SignatureValidity::Valid
+                    } else {
+                        SignatureValidity::Invalid
+                    }
+                } else {
+                    SignatureValidity::ValidNoDigest
+                }
+            } else {
+                SignatureValidity::Invalid
+            }
+        } else {
+            SignatureValidity::Invalid
+        }
+    } else {
+        SignatureValidity::Absent
     }
 }
 

--- a/plume-common/src/activity_pub/sign.rs
+++ b/plume-common/src/activity_pub/sign.rs
@@ -6,6 +6,8 @@ use openssl::{
     rsa::Rsa,
     sha::sha256
 };
+use super::request;
+use rocket::http::HeaderMap;
 use serde_json;
 
 /// Returns (public key, private key)
@@ -26,6 +28,7 @@ pub trait Signer {
 
 pub trait Signable {
     fn sign<T>(&mut self, creator: &T) -> &mut Self where T: Signer;
+    fn verify<T>(self, creator: &T) -> bool where T: Signer;
 
     fn hash(data: String) -> String {
         let bytes = data.into_bytes();
@@ -54,5 +57,86 @@ impl Signable for serde_json::Value {
         options["signatureValue"] = serde_json::Value::String(signature);
         self["signature"] = options;
         self
+    }
+
+    fn verify<T: Signer>(mut self, creator: &T) -> bool {
+        let signature_obj = if let Some(sig) = self.as_object_mut().and_then(|o| o.remove("signature")) {
+            sig
+        } else {
+            //signature not present
+            return false
+        };
+        let signature = if let Ok(sig) = base64::decode(&signature_obj["signatureValue"].as_str().unwrap_or("")) {
+            sig
+        } else {
+            return false
+        };
+        let creation_date = &signature_obj["created"];
+        let options_hash  = Self::hash(json!({
+            "@context": "https://w3id.org/identity/v1",
+            "created": creation_date
+        }).to_string());
+        let document_hash = Self::hash(self.to_string());
+        let to_be_signed = options_hash + &document_hash;
+        creator.verify(to_be_signed, signature)
+    }
+}
+
+#[derive(Debug,Copy,Clone,PartialEq)]
+pub enum SignatureValidity {
+    Invalid,
+    ValidNoDigest,
+    Valid,
+    Absent,
+}
+
+impl SignatureValidity {
+    pub fn is_secure(&self) -> bool {
+        self==&SignatureValidity::Valid
+    }
+}
+
+pub fn verify_http_headers<S: Signer+::std::fmt::Debug>(sender: &S, all_headers: HeaderMap, data: String) -> SignatureValidity{
+    if let Some(sig_header) = all_headers.get_one("Signature") {
+        let mut _key_id = None;
+        let mut _algorithm = None;
+        let mut headers = None;
+        let mut signature = None;
+        for part in sig_header.split(',') {
+            match part {
+                part if part.starts_with("keyId=") => _key_id = Some(&part[7..part.len()-1]),
+                part if part.starts_with("algorithm=") => _algorithm = Some(&part[11..part.len()-1]),
+                part if part.starts_with("headers=") => headers = Some(&part[9..part.len()-1]),
+                part if part.starts_with("signature=") => signature = Some(&part[11..part.len()-1]),
+                _ => {},
+            }
+        }
+        if signature.is_some() && headers.is_some() {
+            let headers = headers.unwrap().split_whitespace().collect::<Vec<_>>();
+            let signature = signature.unwrap();
+            let h = headers.iter()
+                .map(|header| (header,all_headers.get_one(header)))
+                .map(|(header, value)| format!("{}: {}", header.to_lowercase(), value.unwrap_or("")))
+                .collect::<Vec<_>>().join("\n");
+            if sender.verify(h, base64::decode(signature).unwrap_or(Vec::new())) {
+                if headers.contains(&"digest") {
+                    let digest = all_headers.get_one("digest").unwrap_or("");
+                    let digest = request::Digest::from_header(digest);
+                    if digest.map(|d| d.verify(data)).unwrap_or(false) {
+                        SignatureValidity::Valid
+                    } else {
+                        SignatureValidity::Invalid
+                    }
+                } else {
+                    SignatureValidity::ValidNoDigest
+                }
+            } else {
+                SignatureValidity::Invalid
+            }
+        } else {
+            SignatureValidity::Invalid
+        }
+    } else {
+        SignatureValidity::Absent
     }
 }

--- a/plume-common/src/activity_pub/sign.rs
+++ b/plume-common/src/activity_pub/sign.rs
@@ -97,46 +97,47 @@ impl SignatureValidity {
 }
 
 pub fn verify_http_headers<S: Signer+::std::fmt::Debug>(sender: &S, all_headers: HeaderMap, data: String) -> SignatureValidity{
-    if let Some(sig_header) = all_headers.get_one("Signature") {
-        let mut _key_id = None;
-        let mut _algorithm = None;
-        let mut headers = None;
-        let mut signature = None;
-        for part in sig_header.split(',') {
-            match part {
-                part if part.starts_with("keyId=") => _key_id = Some(&part[7..part.len()-1]),
-                part if part.starts_with("algorithm=") => _algorithm = Some(&part[11..part.len()-1]),
-                part if part.starts_with("headers=") => headers = Some(&part[9..part.len()-1]),
-                part if part.starts_with("signature=") => signature = Some(&part[11..part.len()-1]),
-                _ => {},
-            }
+    let sig_header = all_headers.get_one("Signature");
+    if sig_header.is_none() {
+        return SignatureValidity::Absent
+    }
+    let sig_header = sig_header.unwrap();
+
+    let mut _key_id = None;
+    let mut _algorithm = None;
+    let mut headers = None;
+    let mut signature = None;
+    for part in sig_header.split(',') {
+        match part {
+            part if part.starts_with("keyId=") => _key_id = Some(&part[7..part.len()-1]),
+            part if part.starts_with("algorithm=") => _algorithm = Some(&part[11..part.len()-1]),
+            part if part.starts_with("headers=") => headers = Some(&part[9..part.len()-1]),
+            part if part.starts_with("signature=") => signature = Some(&part[11..part.len()-1]),
+            _ => {},
         }
-        if signature.is_some() && headers.is_some() {
-            let headers = headers.unwrap().split_whitespace().collect::<Vec<_>>();
-            let signature = signature.unwrap();
-            let h = headers.iter()
-                .map(|header| (header,all_headers.get_one(header)))
-                .map(|(header, value)| format!("{}: {}", header.to_lowercase(), value.unwrap_or("")))
-                .collect::<Vec<_>>().join("\n");
-            if sender.verify(h, base64::decode(signature).unwrap_or(Vec::new())) {
-                if headers.contains(&"digest") {
-                    let digest = all_headers.get_one("digest").unwrap_or("");
-                    let digest = request::Digest::from_header(digest);
-                    if digest.map(|d| d.verify(data)).unwrap_or(false) {
-                        SignatureValidity::Valid
-                    } else {
-                        SignatureValidity::Invalid
-                    }
-                } else {
-                    SignatureValidity::ValidNoDigest
-                }
-            } else {
-                SignatureValidity::Invalid
-            }
-        } else {
-            SignatureValidity::Invalid
-        }
+    }
+
+    if signature.is_none() || headers.is_none() {//missing part of the header
+        return SignatureValidity::Invalid
+    }
+    let headers = headers.unwrap().split_whitespace().collect::<Vec<_>>();
+    let signature = signature.unwrap();
+    let h = headers.iter()
+        .map(|header| (header,all_headers.get_one(header)))
+        .map(|(header, value)| format!("{}: {}", header.to_lowercase(), value.unwrap_or("")))
+        .collect::<Vec<_>>().join("\n");
+
+    if !sender.verify(h, base64::decode(signature).unwrap_or(Vec::new())) {
+        return SignatureValidity::Invalid
+    }
+    if !headers.contains(&"digest") {// signature is valid, but body content is not verified
+        return SignatureValidity::ValidNoDigest
+    }
+    let digest = all_headers.get_one("digest").unwrap_or("");
+    let digest = request::Digest::from_header(digest);
+    if !digest.map(|d| d.verify(data)).unwrap_or(false) {// signature was valid, but body content does not match its digest
+        SignatureValidity::Invalid
     } else {
-        SignatureValidity::Absent
+	    SignatureValidity::Valid// all check passed
     }
 }

--- a/plume-common/src/activity_pub/sign.rs
+++ b/plume-common/src/activity_pub/sign.rs
@@ -20,6 +20,8 @@ pub trait Signer {
     
     /// Sign some data with the signer keypair
     fn sign(&self, to_sign: String) -> Vec<u8>;
+    /// Verify if the signature is valid
+    fn verify(&self, data: String, signature: Vec<u8>) -> bool;
 }
 
 pub trait Signable {

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -12,7 +12,7 @@ use openssl::{
     hash::MessageDigest,
     pkey::{PKey, Private},
     rsa::Rsa,
-    sign::Signer
+    sign::{Signer,Verifier}
 };
 use webfinger::*;
 
@@ -308,6 +308,13 @@ impl sign::Signer for Blog {
         let mut signer = Signer::new(MessageDigest::sha256(), &key).unwrap();
         signer.update(to_sign.as_bytes()).unwrap();
         signer.sign_to_vec().unwrap()
+    }
+
+    fn verify(&self, data: String, signature: Vec<u8>) -> bool {
+       let key = PKey::from_rsa(Rsa::public_key_from_pem(self.public_key.as_ref()).unwrap()).unwrap();
+       let mut verifier = Verifier::new(MessageDigest::sha256(), &key).unwrap();
+        verifier.update(data.as_bytes()).unwrap();
+        verifier.verify(&signature).unwrap()
     }
 }
 

--- a/plume-models/src/headers.rs
+++ b/plume-models/src/headers.rs
@@ -1,0 +1,17 @@
+use rocket::request::{self, FromRequest, Request};
+use rocket::{http::HeaderMap, Outcome};
+
+
+pub struct Headers<'r>(pub HeaderMap<'r>);
+
+impl<'a, 'r> FromRequest<'a, 'r> for Headers<'r> {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, ()> {
+        let mut headers = HeaderMap::new();
+        for header in request.headers().clone().into_iter() {
+            headers.add(header);
+        }
+        Outcome::Success(Headers(headers))
+    }
+}

--- a/plume-models/src/headers.rs
+++ b/plume-models/src/headers.rs
@@ -21,7 +21,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for Headers<'r> {
         headers.add(Header::new("(request-target)",
                                 format!("{} {}",
                                         request.method().as_str().to_lowercase(),
-                                        uri.to_lowercase())));
+                                        uri)));
         Outcome::Success(Headers(headers))
     }
 }

--- a/plume-models/src/headers.rs
+++ b/plume-models/src/headers.rs
@@ -1,5 +1,5 @@
 use rocket::request::{self, FromRequest, Request};
-use rocket::{http::HeaderMap, Outcome};
+use rocket::{http::{Header, HeaderMap}, Outcome};
 
 
 pub struct Headers<'r>(pub HeaderMap<'r>);
@@ -12,6 +12,16 @@ impl<'a, 'r> FromRequest<'a, 'r> for Headers<'r> {
         for header in request.headers().clone().into_iter() {
             headers.add(header);
         }
+        let ori = request.uri();
+        let uri = if let Some(query) = ori.query() {
+            format!("{}?{}", ori.path(), query)
+        } else {
+            ori.path().to_owned()
+        };
+        headers.add(Header::new("(request-target)",
+                                format!("{} {}",
+                                        request.method().as_str().to_lowercase(),
+                                        uri.to_lowercase())));
         Outcome::Success(Headers(headers))
     }
 }

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -110,6 +110,7 @@ pub mod blogs;
 pub mod comments;
 pub mod db_conn;
 pub mod follows;
+pub mod headers;
 pub mod instance;
 pub mod likes;
 pub mod medias;

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -604,6 +604,13 @@ impl Signer for User {
         signer.update(to_sign.as_bytes()).unwrap();
         signer.sign_to_vec().unwrap()
     }
+
+    fn verify(&self, data: String, signature: Vec<u8>) -> bool {
+        let key = PKey::from_rsa(Rsa::public_key_from_pem(self.public_key.as_ref()).unwrap()).unwrap();
+       let mut verifier = sign::Verifier::new(MessageDigest::sha256(), &key).unwrap();
+        verifier.update(data.as_bytes()).unwrap();
+        verifier.verify(&signature).unwrap()
+    }
 }
 
 impl NewUser {

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -607,7 +607,7 @@ impl Signer for User {
 
     fn verify(&self, data: String, signature: Vec<u8>) -> bool {
         let key = PKey::from_rsa(Rsa::public_key_from_pem(self.public_key.as_ref()).unwrap()).unwrap();
-       let mut verifier = sign::Verifier::new(MessageDigest::sha256(), &key).unwrap();
+        let mut verifier = sign::Verifier::new(MessageDigest::sha256(), &key).unwrap();
         verifier.update(data.as_bytes()).unwrap();
         verifier.verify(&signature).unwrap()
     }

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -200,8 +200,9 @@ fn shared_inbox(conn: DbConn, data: String, headers: Headers) -> String {
         .unwrap_or_else(|| activity["actor"]["id"].as_str().expect("No actor ID for incoming activity, blocks by panicking"));
 
     let actor = User::from_url(&conn, actor_id.to_owned()).unwrap();
-    if !verify_http_headers(&actor, headers.0, data).is_secure() &&
+    if !verify_http_headers(&actor, headers.0.clone(), data).is_secure() &&
         !act.clone().verify(&actor) {
+        println!("Rejected invalid activity supposedly from {}, with headers {:?}", actor.username, headers.0);
         return "invalid signature".to_owned();
     }
 

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -1,9 +1,12 @@
 use gettextrs::gettext;
-use rocket::{request::LenientForm, response::Redirect};
+use rocket::{http::HeaderMap, Outcome,
+    request::{self, FromRequest, LenientForm, Request},
+    response::Redirect};
 use rocket_contrib::{Json, Template};
 use serde_json;
 use validator::{Validate};
 
+use plume_common::activity_pub::{verify_http_headers, SignatureValidity};
 use plume_models::{
     admin::Admin,
     comments::Comment,
@@ -12,7 +15,6 @@ use plume_models::{
     users::User,
     safe_string::SafeString,
     instance::*
-
 };
 use inbox::Inbox;
 use routes::Page;
@@ -189,13 +191,41 @@ fn ban(_admin: Admin, conn: DbConn, id: i32) -> Redirect {
     Redirect::to(uri!(admin_users))
 }
 
+struct Headers<'r> {
+    headers: HeaderMap<'r>,
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Headers<'r> {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) ->request::Outcome<Self, ()> {
+        let mut headers = HeaderMap::new();
+        for header in request.headers().clone().into_iter() {
+            headers.add(header);
+        }
+        Outcome::Success(Headers{headers})
+    }
+}
+
 #[post("/inbox", data = "<data>")]
-fn shared_inbox(conn: DbConn, data: String) -> String {
+fn shared_inbox(conn: DbConn, data: String, headers: Headers) -> String {
     let act: serde_json::Value = serde_json::from_str(&data[..]).unwrap();
 
     let activity = act.clone();
     let actor_id = activity["actor"].as_str()
         .unwrap_or_else(|| activity["actor"]["id"].as_str().expect("No actor ID for incoming activity, blocks by panicking"));
+
+    let sig = match verify_http_headers(&User::from_url(&conn, actor_id.to_owned()).unwrap(), headers.headers, data) {
+        SignatureValidity::Valid => true,
+        _ => {
+            // TODO verify json signature
+            false
+        }
+    };
+    if !sig {
+        return "invalid signature".to_owned();
+    }
+
     if Instance::is_blocked(&*conn, actor_id.to_string()) {
         return String::new();
     }

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -306,8 +306,9 @@ fn inbox(name: String, conn: DbConn, data: String, headers: Headers) -> String {
         .unwrap_or_else(|| activity["actor"]["id"].as_str().expect("User: No actor ID for incoming activity, blocks by panicking"));
 
     let actor = User::from_url(&conn, actor_id.to_owned()).unwrap();
-    if !verify_http_headers(&actor, headers.0, data).is_secure() &&
+    if !verify_http_headers(&actor, headers.0.clone(), data).is_secure() &&
         !act.clone().verify(&actor) {
+        println!("Rejected invalid activity supposedly from {}, with headers {:?}", actor.username, headers.0);
         return "invalid signature".to_owned();
     }
 


### PR DESCRIPTION
Verify signature for incoming activity. This is still work in progress
Fix #10

Todo:
- [X] Verify HTTP signature
- [x] Verify JSON-ld signature

Federation status at this time:
- [X] itself
- [x] older Plume
- [x] other ActivityPub implementations (Mastoodn, Pleroma tested)

Side-note:
As this as the ability to totally break federation, we should wait to be sure it does work with at least Mastodon, Pleroma and older Plume before merging this