### PR TITLE
Fix Welcome banner grammar

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -63,7 +63,7 @@ msgstr "Name"
 msgid "Let&#x27;s go!"
 msgstr "Los geht's!"
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr "Willkommen auf {{ instance_name | escape }}"
 
 msgid "Notifications"

--- a/po/en.po
+++ b/po/en.po
@@ -61,8 +61,8 @@ msgid "Let&#x27;s go!"
 msgstr ""
 
 #, fuzzy
-msgid "Welcome on {{ instance_name | escape }}"
-msgstr "Welcome on {{ instance_name }}"
+msgid "Welcome to {{ instance_name | escape }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "Notifications"
 msgstr ""
@@ -150,7 +150,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Open on {{ instance_url }}"
-msgstr "Welcome on {{ instance_name }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "Follow"
 msgstr ""
@@ -414,7 +414,7 @@ msgstr ""
 
 #, fuzzy
 msgid "About {{ instance_name }}"
-msgstr "Welcome on {{ instance_name }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "Home to"
 msgstr ""
@@ -527,14 +527,14 @@ msgstr ""
 
 #, fuzzy
 msgid "Articles from {{ instance.name }}"
-msgstr "Welcome on {{ instance_name }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "View all"
 msgstr ""
 
 #, fuzzy
 msgid "Articles tagged \"{{ tag }}\""
-msgstr "Welcome on {{ instance_name }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "Edit"
 msgstr ""
@@ -559,7 +559,7 @@ msgstr ""
 
 #, fuzzy
 msgid "Administration of {{ instance.name }}"
-msgstr "Welcome on {{ instance_name }}"
+msgstr "Welcome to {{ instance_name }}"
 
 msgid "Instances"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -66,7 +66,7 @@ msgstr "Nom"
 msgid "Let&#x27;s go!"
 msgstr "C’est parti !"
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr "Bienvenue sur {{ instance_name | escape }}"
 
 msgid "Notifications"

--- a/po/gl.po
+++ b/po/gl.po
@@ -60,7 +60,7 @@ msgstr "Nome"
 msgid "Let&#x27;s go!"
 msgstr "Imos!"
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr "Ben vida a {{ instance_name | escape }}"
 
 msgid "Notifications"

--- a/po/nb.po
+++ b/po/nb.po
@@ -62,7 +62,7 @@ msgstr "Navn"
 msgid "Let&#x27;s go!"
 msgstr "Kjør på!"
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr "Velkommen til {{ instance_name | escape }}"
 
 msgid "Notifications"

--- a/po/pl.po
+++ b/po/pl.po
@@ -63,7 +63,7 @@ msgstr "Nazwa"
 msgid "Let&#x27;s go!"
 msgstr "Przejdźmy dalej!"
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr "Witamy na {{ instance_name | escape }}"
 
 msgid "Notifications"

--- a/po/plume.pot
+++ b/po/plume.pot
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Let&#x27;s go!"
 msgstr ""
 
-msgid "Welcome on {{ instance_name | escape }}"
+msgid "Welcome to {{ instance_name | escape }}"
 msgstr ""
 
 msgid "Notifications"

--- a/templates/instance/index.html.tera
+++ b/templates/instance/index.html.tera
@@ -6,7 +6,7 @@
 {% endblock title %}
 
 {% block content %}
-    <h1>{{ "Welcome on {{ instance_name | escape }}" | _(instance_name=instance.name) }}</h1>
+    <h1>{{ "Welcome to {{ instance_name | escape }}" | _(instance_name=instance.name) }}</h1>
 
     {% if account %}
         {{ macros::tabs(links=['/', '/feed', '/federated', '/local'], titles=['Latest articles', 'Your feed', 'Federated feed', 'Local feed'], selected=1) }}


### PR DESCRIPTION
Typically one would say "Welcome to {My Blog}" in English instead of "Welcome on {My Blog}". So this PR changes that.