### PR TITLE
Panic less and with better messages

### DIFF
--- a/plume-cli/src/main.rs
+++ b/plume-cli/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     match matches.subcommand() {
         ("instance", Some(args)) => instance::run(args, &conn.expect("Couldn't connect to the database.")),
         ("users", Some(args)) => users::run(args, &conn.expect("Couldn't connect to the database.")),
-        _ => app.print_help().unwrap()
+        _ => app.print_help().expect("Couldn't print help")
     };
 }
 

--- a/plume-common/src/activity_pub/inbox.rs
+++ b/plume-common/src/activity_pub/inbox.rs
@@ -17,7 +17,7 @@ pub trait FromActivity<T: Object, C>: Sized {
 
     fn try_from_activity(conn: &C, act: Create) -> bool {
         if let Ok(obj) = act.create_props.object_object() {
-            Self::from_activity(conn, obj, act.create_props.actor_link::<Id>().unwrap());
+            Self::from_activity(conn, obj, act.create_props.actor_link::<Id>().expect("FromActivity::try_from_activity: id not found error"));
             true
         } else {
             false

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -53,7 +53,7 @@ macro_rules! find_by {
                 $(.filter($table::$col.eq($col)))+
                 .limit(1)
                 .load::<Self>(conn)
-                .expect("Error loading $table by $col")
+                .expect("macro::find_by: Error loading $table by $col")
                 .into_iter().nth(0)
         }
     };
@@ -78,7 +78,7 @@ macro_rules! list_by {
             $table::table
                 $(.filter($table::$col.eq($col)))+
                 .load::<Self>(conn)
-                .expect("Error loading $table by $col")
+                .expect("macro::list_by: Error loading $table by $col")
         }
     };
 }
@@ -101,7 +101,7 @@ macro_rules! get {
             $table::table.filter($table::id.eq(id))
                 .limit(1)
                 .load::<Self>(conn)
-                .expect("Error loading $table by id")
+                .expect("macro::get: Error loading $table by id")
                 .into_iter().nth(0)
         }
     };
@@ -127,7 +127,7 @@ macro_rules! insert {
             diesel::insert_into($table::table)
                 .values(new)
                 .execute(conn)
-                .expect("Error saving new $table");
+                .expect("macro::insert: Error saving new $table");
             Self::last(conn)
         }
     };
@@ -154,9 +154,9 @@ macro_rules! update {
             diesel::update(self)
                 .set(self)
                 .execute(conn)
-                .expect(concat!("Error updating ", stringify!($table)));
+                .expect(concat!("macro::update: Error updating ", stringify!($table)));
             Self::get(conn, self.id)
-                .expect(concat!(stringify!($table), " we just updated doesn't exist anymore???"))
+                .expect(concat!("macro::update: ", stringify!($table), " we just updated doesn't exist anymore???"))
         }
     };
 }
@@ -179,9 +179,9 @@ macro_rules! last {
             $table::table.order_by($table::id.desc())
                 .limit(1)
                 .load::<Self>(conn)
-                .expect(concat!("Error getting last ", stringify!($table)))
+                .expect(concat!("macro::last: Error getting last ", stringify!($table)))
                 .iter().next()
-                .expect(concat!("No last ", stringify!($table)))
+                .expect(concat!("macro::last: No last ", stringify!($table)))
                 .clone()
         }
     };

--- a/plume-models/src/mentions.rs
+++ b/plume-models/src/mentions.rs
@@ -57,16 +57,16 @@ impl Mention {
     pub fn build_activity(conn: &Connection, ment: String) -> link::Mention {
         let user = User::find_by_fqn(conn, ment.clone());
         let mut mention = link::Mention::default();
-        mention.link_props.set_href_string(user.clone().map(|u| u.ap_url).unwrap_or(String::new())).expect("Error setting mention's href");
-        mention.link_props.set_name_string(format!("@{}", ment)).expect("Error setting mention's name");
+        mention.link_props.set_href_string(user.clone().map(|u| u.ap_url).unwrap_or(String::new())).expect("Mention::build_activity: href error");
+        mention.link_props.set_name_string(format!("@{}", ment)).expect("Mention::build_activity: name error:");
         mention
     }
 
     pub fn to_activity(&self, conn: &Connection) -> link::Mention {
         let user = self.get_mentioned(conn);
         let mut mention = link::Mention::default();
-        mention.link_props.set_href_string(user.clone().map(|u| u.ap_url).unwrap_or(String::new())).expect("Error setting mention's href");
-        mention.link_props.set_name_string(user.map(|u| format!("@{}", u.get_fqn(conn))).unwrap_or(String::new())).expect("Error setting mention's name");
+        mention.link_props.set_href_string(user.clone().map(|u| u.ap_url).unwrap_or(String::new())).expect("Mention::to_activity: href error");
+        mention.link_props.set_name_string(user.map(|u| format!("@{}", u.get_fqn(conn))).unwrap_or(String::new())).expect("Mention::to_activity: mention error");
         mention
     }
 

--- a/plume-models/src/notifications.rs
+++ b/plume-models/src/notifications.rs
@@ -45,7 +45,7 @@ impl Notification {
         notifications::table.filter(notifications::user_id.eq(user.id))
             .order_by(notifications::creation_date.desc())
             .load::<Notification>(conn)
-            .expect("Couldn't load user notifications")
+            .expect("Notification::find_for_user: notification loading error")
     }
 
     pub fn page_for_user(conn: &Connection, user: &User, (min, max): (i32, i32)) -> Vec<Notification> {
@@ -54,7 +54,7 @@ impl Notification {
             .offset(min.into())
             .limit((max - min).into())
             .load::<Notification>(conn)
-            .expect("Couldn't load user notifications page")
+            .expect("Notification::page_for_user: notification loading error")
     }
 
     pub fn find<S: Into<String>>(conn: &Connection, kind: S, obj: i32) -> Option<Notification> {
@@ -90,9 +90,9 @@ impl Notification {
                     "user": mention.get_user(conn).map(|u| u.to_json(conn)),
                     "url": mention.get_post(conn).map(|p| p.to_json(conn)["url"].clone())
                         .unwrap_or_else(|| {
-                            let comment = mention.get_comment(conn).expect("No comment nor post for mention");
+                            let comment = mention.get_comment(conn).expect("Notification::to_json: comment not found error");
                             let post = comment.get_post(conn).to_json(conn);
-                            json!(format!("{}#comment-{}", post["url"].as_str().unwrap(), comment.id))
+                            json!(format!("{}#comment-{}", post["url"].as_str().expect("Notification::to_json: post url error"), comment.id))
                         })
                 })
             ),

--- a/plume-models/src/reshares.rs
+++ b/plume-models/src/reshares.rs
@@ -37,10 +37,10 @@ impl Reshare {
             diesel::update(self)
                 .set(reshares::ap_url.eq(format!(
                     "{}/reshare/{}",
-                    User::get(conn, self.user_id).unwrap().ap_url,
-                    Post::get(conn, self.post_id).unwrap().ap_url
+                    User::get(conn, self.user_id).expect("Reshare::update_ap_url: user error").ap_url,
+                    Post::get(conn, self.post_id).expect("Reshare::update_ap_url: post error").ap_url
                 )))
-                .execute(conn).expect("Couldn't update AP URL");
+                .execute(conn).expect("Reshare::update_ap_url: update error");
         }
     }
 
@@ -49,7 +49,7 @@ impl Reshare {
             .order(reshares::creation_date.desc())
             .limit(limit)
             .load::<Reshare>(conn)
-            .expect("Error loading recent reshares for user")
+            .expect("Reshare::get_recents_for_author: loading error")
     }
 
     pub fn get_post(&self, conn: &Connection) -> Option<Post> {
@@ -62,9 +62,11 @@ impl Reshare {
 
     pub fn into_activity(&self, conn: &Connection) -> Announce {
         let mut act = Announce::default();
-        act.announce_props.set_actor_link(User::get(conn, self.user_id).unwrap().into_id()).unwrap();
-        act.announce_props.set_object_link(Post::get(conn, self.post_id).unwrap().into_id()).unwrap();
-        act.object_props.set_id_string(self.ap_url.clone()).unwrap();
+        act.announce_props.set_actor_link(User::get(conn, self.user_id).expect("Reshare::into_activity: user error").into_id())
+            .expect("Reshare::into_activity: actor error");
+        act.announce_props.set_object_link(Post::get(conn, self.post_id).expect("Reshare::into_activity: post error").into_id())
+            .expect("Reshare::into_activity: object error");
+        act.object_props.set_id_string(self.ap_url.clone()).expect("Reshare::into_activity: id error");
         act.object_props.set_to_link(Id::new(PUBLIC_VISIBILTY.to_string())).expect("Reshare::into_activity: to error");
         act.object_props.set_cc_link_vec::<Id>(vec![]).expect("Reshare::into_activity: cc error");
 
@@ -77,8 +79,8 @@ impl FromActivity<Announce, Connection> for Reshare {
         let user = User::from_url(conn, announce.announce_props.actor_link::<Id>().expect("Reshare::from_activity: actor error").into());
         let post = Post::find_by_ap_url(conn, announce.announce_props.object_link::<Id>().expect("Reshare::from_activity: object error").into());
         let reshare = Reshare::insert(conn, NewReshare {
-            post_id: post.unwrap().id,
-            user_id: user.unwrap().id,
+            post_id: post.expect("Reshare::from_activity: post error").id,
+            user_id: user.expect("Reshare::from_activity: user error").id,
             ap_url: announce.object_props.id_string().unwrap_or(String::from(""))
         });
         reshare.notify(conn);
@@ -88,7 +90,7 @@ impl FromActivity<Announce, Connection> for Reshare {
 
 impl Notify<Connection> for Reshare {
     fn notify(&self, conn: &Connection) {
-        let post = self.get_post(conn).unwrap();
+        let post = self.get_post(conn).expect("Reshare::notify: post error");
         for author in post.get_authors(conn) {
             Notification::insert(conn, NewNotification {
                 kind: notification_kind::RESHARE.to_string(),
@@ -101,16 +103,16 @@ impl Notify<Connection> for Reshare {
 
 impl Deletable<Connection, Undo> for Reshare {
     fn delete(&self, conn: &Connection) -> Undo {
-        diesel::delete(self).execute(conn).unwrap();
+        diesel::delete(self).execute(conn).expect("Reshare::delete: delete error");
 
         // delete associated notification if any
         if let Some(notif) = Notification::find(conn, notification_kind::RESHARE, self.id) {
-            diesel::delete(&notif).execute(conn).expect("Couldn't delete reshare notification");
+            diesel::delete(&notif).execute(conn).expect("Reshare::delete: notification error");
         }
 
         let mut act = Undo::default();
-        act.undo_props.set_actor_link(User::get(conn, self.user_id).unwrap().into_id()).unwrap();
-        act.undo_props.set_object_object(self.into_activity(conn)).unwrap();
+        act.undo_props.set_actor_link(User::get(conn, self.user_id).expect("Reshare::delete: user error").into_id()).expect("Reshare::delete: actor error");
+        act.undo_props.set_object_object(self.into_activity(conn)).expect("Reshare::delete: object error");
         act.object_props.set_id_string(format!("{}#delete", self.ap_url)).expect("Reshare::delete: id error");
         act.object_props.set_to_link(Id::new(PUBLIC_VISIBILTY.to_string())).expect("Reshare::delete: to error");
         act.object_props.set_cc_link_vec::<Id>(vec![]).expect("Reshare::delete: cc error");

--- a/plume-models/src/tags.rs
+++ b/plume-models/src/tags.rs
@@ -29,7 +29,10 @@ impl Tag {
 
     pub fn into_activity(&self, conn: &Connection) -> Hashtag {
         let mut ht = Hashtag::default();
-        ht.set_href_string(ap_url(format!("{}/tag/{}", Instance::get_local(conn).unwrap().public_domain, self.tag))).expect("Tag::into_activity: href error");
+        ht.set_href_string(ap_url(format!("{}/tag/{}",
+                                          Instance::get_local(conn).expect("Tag::into_activity: local instance not found error").public_domain,
+                                          self.tag)
+                                  )).expect("Tag::into_activity: href error");
         ht.set_name_string(self.tag.clone()).expect("Tag::into_activity: name error");
         ht
     }

--- a/src/api/posts.rs
+++ b/src/api/posts.rs
@@ -19,7 +19,7 @@ fn get(id: i32, conn: DbConn) -> Json<serde_json::Value> {
 
 #[get("/posts")]
 fn list(conn: DbConn, uri: &Origin) -> Json<serde_json::Value> {
-    let query: PostEndpoint = serde_qs::from_str(uri.query().unwrap_or("")).expect("Invalid query string");
+    let query: PostEndpoint = serde_qs::from_str(uri.query().unwrap_or("")).expect("api::list: invalid query error");
     let post = <Post as Provider<Connection>>::list(&*conn, query);
     Json(json!(post))
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -16,7 +16,7 @@ use plume_models::{
 
 pub trait Inbox {
     fn received(&self, conn: &Connection, act: serde_json::Value) -> Result<(), Error> {
-        let actor_id = Id::new(act["actor"].as_str().unwrap_or_else(|| act["actor"]["id"].as_str().expect("No actor ID for incoming activity")));
+        let actor_id = Id::new(act["actor"].as_str().unwrap_or_else(|| act["actor"]["id"].as_str().expect("Inbox::received: actor_id missing error")));
         match act["type"].as_str() {
             Some(t) => {
                 match t {
@@ -47,7 +47,7 @@ pub trait Inbox {
                     },
                     "Undo" => {
                         let act: Undo = serde_json::from_value(act.clone())?;
-                        match act.undo_props.object["type"].as_str().unwrap() {
+                        match act.undo_props.object["type"].as_str().expect("Inbox::received: undo without original type error") {
                             "Like" => {
                                 likes::Like::delete_id(act.undo_props.object_object::<Like>()?.object_props.id_string()?, conn);
                                 Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn init_pool() -> Option<DbPool> {
 }
 
 fn main() {
-    let pool = init_pool().expect("Couldn't intialize database pool");
+    let pool = init_pool().expect("main: database pool initialization error");
     rocket::ignite()
         .mount("/", routes![
             routes::blogs::paginated_details,
@@ -176,6 +176,6 @@ fn main() {
                     ("/login".to_owned(), "/login".to_owned(), rocket::http::Method::Post),
                     ("/users/new".to_owned(), "/users/new".to_owned(), rocket::http::Method::Post),
                 ])
-                .finalize().unwrap())
+                .finalize().expect("main: csrf fairing creation error"))
         .launch();
 }

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -6,21 +6,21 @@ use plume_models::users::User;
 
 #[catch(404)]
 fn not_found(req: &Request) -> Template {
-    let conn = req.guard::<DbConn>().expect("404: DbConn error");
+    let conn = req.guard::<DbConn>().succeeded();
     let user = User::from_request(req).succeeded();
     Template::render("errors/404", json!({
         "error_message": "Page not found",
-        "account": user.map(|u| u.to_json(&*conn))
+        "account": user.and_then(|u| conn.map(|conn| u.to_json(&*conn)))
     }))
 }
 
 #[catch(500)]
 fn server_error(req: &Request) -> Template {
-    let conn = req.guard::<DbConn>().expect("500: DbConn error");
+    let conn = req.guard::<DbConn>().succeeded();
     let user = User::from_request(req).succeeded();
     Template::render("errors/500", json!({
         "error_message": "Server error",
-        "account": user.map(|u| u.to_json(&*conn))
+        "account": user.and_then(|u| conn.map(|conn| u.to_json(&*conn)))
     }))
 }
 

--- a/src/routes/likes.rs
+++ b/src/routes/likes.rs
@@ -12,9 +12,9 @@ use plume_models::{
 };
 
 #[post("/~/<blog>/<slug>/like")]
-fn create(blog: String, slug: String, user: User, conn: DbConn, worker: State<Pool<ThunkWorker<()>>>) -> Redirect {
-    let b = Blog::find_by_fqn(&*conn, blog.clone()).unwrap();
-    let post = Post::find_by_slug(&*conn, slug.clone(), b.id).unwrap();
+fn create(blog: String, slug: String, user: User, conn: DbConn, worker: State<Pool<ThunkWorker<()>>>) -> Option<Redirect> {
+    let b = Blog::find_by_fqn(&*conn, blog.clone())?;
+    let post = Post::find_by_slug(&*conn, slug.clone(), b.id)?;
 
     if !user.has_liked(&*conn, &post) {
         let like = likes::Like::insert(&*conn, likes::NewLike {
@@ -29,13 +29,13 @@ fn create(blog: String, slug: String, user: User, conn: DbConn, worker: State<Po
         let act = like.into_activity(&*conn);
         worker.execute(Thunk::of(move || broadcast(&user, act, dest)));
     } else {
-        let like = likes::Like::find_by_user_on_post(&*conn, user.id, post.id).unwrap();
+        let like = likes::Like::find_by_user_on_post(&*conn, user.id, post.id).expect("likes::create: like exist but not found error");
         let delete_act = like.delete(&*conn);
         let dest = User::one_by_instance(&*conn);
         worker.execute(Thunk::of(move || broadcast(&user, delete_act, dest)));
     }
 
-    Redirect::to(uri!(super::posts::details: blog = blog, slug = slug))
+    Some(Redirect::to(uri!(super::posts::details: blog = blog, slug = slug)))
 }
 
 #[post("/~/<blog>/<slug>/like", rank = 2)]

--- a/src/routes/tags.rs
+++ b/src/routes/tags.rs
@@ -10,19 +10,19 @@ use plume_models::{
 use routes::Page;
 
 #[get("/tag/<name>")]
-fn tag(user: Option<User>, conn: DbConn, name: String) -> Template {
+fn tag(user: Option<User>, conn: DbConn, name: String) -> Option<Template> {
     paginated_tag(user, conn, name, Page::first())
 }
 
 #[get("/tag/<name>?<page>")]
-fn paginated_tag(user: Option<User>, conn: DbConn, name: String, page: Page) -> Template {
-    let tag = Tag::find_by_name(&*conn, name).expect("Rendering tags::tag: tag not found");
+fn paginated_tag(user: Option<User>, conn: DbConn, name: String, page: Page) -> Option<Template> {
+    let tag = Tag::find_by_name(&*conn, name)?;
     let posts = Post::list_by_tag(&*conn, tag.tag.clone(), page.limits());
-    Template::render("tags/index", json!({
+    Some(Template::render("tags/index", json!({
         "tag": tag.clone(),
         "account": user.map(|u| u.to_json(&*conn)),
         "articles": posts.into_iter().map(|p| p.to_json(&*conn)).collect::<Vec<serde_json::Value>>(),
         "page": page.page,
         "n_pages": Page::total(Post::count_for_tag(&*conn, tag.tag) as i32)
-    }))
+    })))
 }


### PR DESCRIPTION
Fix #21 
Change most unwrap to expect, and don't panic when it can be avoided. Also return better http codes, i.e. 400 and 404, when appropriate.
The trait `rocker::request::FromParam` should probably be implemented for Post, Blog, Media, User and Tag. Then we wouldn't need to return `Option`s whenever an entity does not exist, and just let Rocket do the work for us