### PR TITLE
Add support for blog deletion

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -434,6 +434,9 @@ msgstr ""
 msgid "Delete this article"
 msgstr ""
 
+msgid "Delete this blog"
+msgstr ""
+
 msgid "And connected to"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -445,6 +445,9 @@ msgstr "Lire les règles détaillées"
 msgid "Delete this article"
 msgstr "Supprimer cet article"
 
+msgid "Delete this blog"
+msgstr "Supprimer ce blog"
+
 msgid "And connected to"
 msgstr "Et connectée à"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -433,6 +433,9 @@ msgstr "Lea o detalle das normas"
 msgid "Delete this article"
 msgstr "Borrar este artigo"
 
+msgid "Delete this blog"
+msgstr "Borrar este blog"
+
 msgid "And connected to"
 msgstr "E conectada a"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -442,6 +442,9 @@ msgstr "Les reglene"
 msgid "Delete this article"
 msgstr "Siste artikler"
 
+msgid "Delete this blog"
+msgstr ""
+
 msgid "And connected to"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -446,6 +446,9 @@ msgstr "Przeczytaj szczegółowe zasady"
 msgid "Delete this article"
 msgstr "Usuń ten artykuł"
 
+msgid "Delete this blog"
+msgstr ""
+
 msgid "And connected to"
 msgstr "Połączony z"
 

--- a/po/plume.pot
+++ b/po/plume.pot
@@ -424,6 +424,9 @@ msgstr ""
 msgid "Delete this article"
 msgstr ""
 
+msgid "Delete this blog"
+msgstr ""
+
 msgid "And connected to"
 msgstr ""
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ fn main() {
             routes::blogs::new,
             routes::blogs::new_auth,
             routes::blogs::create,
+            routes::blogs::delete,
             routes::blogs::atom_feed,
 
             routes::comments::create,

--- a/templates/blogs/details.html.tera
+++ b/templates/blogs/details.html.tera
@@ -40,4 +40,11 @@
         </div>
         {{ macros::paginate(page=page, total=n_pages) }}
     </section>
+    {% if is_author %}
+    <h2>{{ "Danger zone" | _ }}</h2>
+    <p>{{ "Be very careful, any action taken here can't be cancelled." | _ }}
+    <form method="post" action="/~/{{ blog.fqn }}/delete">
+	    <input type="submit" class="inline-block button destructive" value="{{ "Delete this blog" | _ }}">
+    </form>
+    {% endif %}
 {% endblock content %}


### PR DESCRIPTION
fix #181

At the moment it is done in a similar way to user deletion, i.e. post deletion is not federated, whereas it should probably be. Tell me if I have to implement that part too before merging.

There is a new string to translate ("Delete this blog") however I don't know well how gettext work so I did not add it to `.po`s