### PR TITLE
Fix editor auto-expansion

### DIFF
--- a/static/js/autoExpand.js
+++ b/static/js/autoExpand.js
@@ -1,7 +1,7 @@
-function autosize (el) {
-  el.style.height = 'auto'
-  el.style.height = `${el.scrollHeight}px`
-}
-
 const articleContent = document.querySelector('#plume-editor')
-articleContent.addEventListener('keyup', () => autosize(articleContent))
+const offset = articleContent.offsetHeight - articleContent.clientHeight
+
+articleContent.addEventListener('keydown', () => {
+  articleContent.style.height = 'auto'
+  articleContent.style.height = `${articleContent.scrollHeight - offset}px`
+})

--- a/static/js/autoExpand.js
+++ b/static/js/autoExpand.js
@@ -1,9 +1,7 @@
-function autosize () {
-  const el = this
+function autosize (el) {
   el.style.height = 'auto'
   el.style.height = `${el.scrollHeight}px`
 }
 
-const articleContent = document.querySelector('#content')
-autosize.bind(articleContent)()
-articleContent.addEventListener('keyup', autosize)
+const articleContent = document.querySelector('#plume-editor')
+articleContent.addEventListener('keyup', () => autosize(articleContent))

--- a/templates/posts/details.html.tera
+++ b/templates/posts/details.html.tera
@@ -104,12 +104,12 @@
 
             {% if account %}
                 <form method="post" action="{{ article.url }}comment">
-                    <label for="content">{{ "Your comment" | _ }}</label>
+                    <label for="plume-editor">{{ "Your comment" | _ }}</label>
                     {% if previous %}
                         <input type="hidden" name="responding_to" value="{{ previous.id }}"/>
                     {% endif %}
                     {# Ugly, but we don't have the choice if we don't want weird paddings #}
-                    <textarea id="content" name="content">{% filter trim %}{% if previous %}{% if previous.author.fqn != user_fqn %}@{{ previous.author.fqn }} {% endif %}{% for mention in previous.mentions %}{% if mention != user_fqn %}@{{ mention }} {% endif %}{% endfor %}{% endif %}{% endfilter %}</textarea>
+                    <textarea id="plume-editor" name="content">{% filter trim %}{% if previous %}{% if previous.author.fqn != user_fqn %}@{{ previous.author.fqn }} {% endif %}{% for mention in previous.mentions %}{% if mention != user_fqn %}@{{ mention }} {% endif %}{% endfor %}{% endif %}{% endfilter %}</textarea>
                     <input type="submit" value="{{ "Submit comment" | _ }}" />
                 </form>
             {%  endif %}

--- a/templates/posts/new.html.tera
+++ b/templates/posts/new.html.tera
@@ -27,7 +27,7 @@
         {% endfor %}
     {% endif %}
 
-    <label for="content">{{ "Content" | _ }}<small>{{ "Markdown is supported" | _ }}</small></label>
+     <label for="plume-editor">{{ "Content" | _ }}<small>{{ "Markdown is supported" | _ }}</small></label>
     <textarea id="plume-editor" name="content" rows="20">{{ form.content | default(value="") }}</textarea>
 
     {{ macros::input(name="tags", label="Tags, separated by commas", errors=errors, form=form, optional=true) }}

--- a/templates/posts/new.html.tera
+++ b/templates/posts/new.html.tera
@@ -28,7 +28,7 @@
     {% endif %}
 
     <label for="content">{{ "Content" | _ }}<small>{{ "Markdown is supported" | _ }}</small></label>
-    <textarea id="content" name="content" rows="20">{{ form.content | default(value="") }}</textarea>
+    <textarea id="plume-editor" name="content" rows="20">{{ form.content | default(value="") }}</textarea>
 
     {{ macros::input(name="tags", label="Tags, separated by commas", errors=errors, form=form, optional=true) }}
 


### PR DESCRIPTION
Fixes #237 

Another element with the `content` ID was present in the header.