### PR TITLE
Divers work on tags and mentions

### DIFF
--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -5,6 +5,7 @@ use rocket::{
     http::uri::Uri,
     response::{Redirect, Flash}
 };
+use std::collections::HashSet;
 
 /// Remove non alphanumeric characters and CamelCase a string
 pub fn make_actor_id(name: String) -> String {
@@ -29,7 +30,7 @@ enum State {
 }
 
 /// Returns (HTML, mentions, hashtags)
-pub fn md_to_html(md: &str) -> (String, Vec<String>, Vec<String>) {
+pub fn md_to_html(md: &str) -> (String, HashSet<String>, HashSet<String>) {
     let parser = Parser::new_ext(md, Options::all());
 
     let (parser, mentions, hashtags): (Vec<Vec<Event>>, Vec<Vec<String>>, Vec<Vec<String>>) = parser.map(|evt| match evt {
@@ -129,8 +130,7 @@ pub fn md_to_html(md: &str) -> (String, Vec<String>, Vec<String>) {
 
     let mut buf = String::new();
     html::push_html(&mut buf, parser);
-    let hashtags = hashtags.collect();
-    (buf, mentions.collect(), hashtags)
+    (buf, mentions.collect(), hashtags.collect())
 }
 
 #[cfg(test)]

--- a/plume-models/src/mentions.rs
+++ b/plume-models/src/mentions.rs
@@ -102,6 +102,12 @@ impl Mention {
             })
         }
     }
+
+    pub fn delete(&self, conn: &Connection) {
+        //find related notifications and delete them
+        Notification::find(conn, notification_kind::MENTION, self.id).map(|n| n.delete(conn));
+        diesel::delete(self).execute(conn).expect("Mention::delete: mention deletion error");
+    }
 }
 
 impl Notify<Connection> for Mention {

--- a/plume-models/src/notifications.rs
+++ b/plume-models/src/notifications.rs
@@ -106,4 +106,8 @@ impl Notification {
         });
         json
     }
+
+    pub fn delete(&self, conn: &Connection) {
+        diesel::delete(self).execute(conn).expect("Notification::delete: notification deletion error");
+    }
 }

--- a/plume-models/src/posts.rs
+++ b/plume-models/src/posts.rs
@@ -475,6 +475,9 @@ impl Deletable<Connection, Delete> for Post {
         act.object_props.set_id_string(format!("{}#delete", self.ap_url)).expect("Post::delete: id error");
         act.object_props.set_to_link_vec(vec![Id::new(PUBLIC_VISIBILTY)]).expect("Post::delete: to error");
 
+        for m in Mention::list_for_post(&conn, self.id) {
+            m.delete(conn);
+        }
         diesel::delete(self).execute(conn).expect("Post::delete: DB error");
         act
     }

--- a/plume-models/src/tags.rs
+++ b/plume-models/src/tags.rs
@@ -45,6 +45,16 @@ impl Tag {
         })
     }
 
+    pub fn build_activity(conn: &Connection, tag: String) -> Hashtag {
+        let mut ht = Hashtag::default();
+        ht.set_href_string(ap_url(format!("{}/tag/{}",
+                                          Instance::get_local(conn).expect("Tag::into_activity: local instance not found error").public_domain,
+                                          tag)
+                                  )).expect("Tag::into_activity: href error");
+        ht.set_name_string(tag).expect("Tag::into_activity: name error");
+        ht
+    }
+
     pub fn delete(&self, conn: &Connection) {
         diesel::delete(self).execute(conn).expect("Tag::delete: database error");
     }

--- a/plume-models/src/tags.rs
+++ b/plume-models/src/tags.rs
@@ -37,10 +37,10 @@ impl Tag {
         ht
     }
 
-    pub fn from_activity(conn: &Connection, tag: Hashtag, post: i32) -> Tag {
+    pub fn from_activity(conn: &Connection, tag: Hashtag, post: i32, is_hashtag: bool) -> Tag {
         Tag::insert(conn, NewTag {
             tag: tag.name_string().expect("Tag::from_activity: name error"),
-            is_hashtag: false,
+            is_hashtag,
             post_id: post
         })
     }

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -207,16 +207,7 @@ fn update(blog: String, slug: String, user: User, conn: DbConn, data: LenientFor
             let post = post.update_ap_url(&*conn);
 
             if post.published {
-                let old_mentions = Mention::list_for_post(&conn, post.id);
-                let old_user_mentioned = old_mentions.iter()
-                    .filter_map(|m| User::get(&conn, m.mentioned_id).map(|u| u.get_fqn(&conn)))
-                    .collect::<HashSet<_>>();
-                for m in mentions.difference(&old_user_mentioned).into_iter() {
-                    Mention::from_activity(&*conn, Mention::build_activity(&*conn, m.clone()), post.id, true, true);
-                }
-                for m in old_mentions.iter().filter(|m| !User::get(&conn, m.mentioned_id).map(|u| mentions.contains(&u.get_fqn(&conn))).unwrap_or(false)) {
-                    m.delete(&conn);
-                }
+                post.update_mentions(&conn, mentions.into_iter().map(|m| Mention::build_activity(&conn, m)).collect());
             }
 
             let old_tags = Tag::for_post(&*conn, post.id).into_iter().collect::<Vec<_>>();

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -207,8 +207,15 @@ fn update(blog: String, slug: String, user: User, conn: DbConn, data: LenientFor
             let post = post.update_ap_url(&*conn);
 
             if post.published {
-                for m in mentions.into_iter() {
-                    Mention::from_activity(&*conn, Mention::build_activity(&*conn, m), post.id, true, true);
+                let old_mentions = Mention::list_for_post(&conn, post.id);
+                let old_user_mentioned = old_mentions.iter()
+                    .filter_map(|m| User::get(&conn, m.mentioned_id).map(|u| u.get_fqn(&conn)))
+                    .collect::<HashSet<_>>();
+                for m in mentions.difference(&old_user_mentioned).into_iter() {
+                    Mention::from_activity(&*conn, Mention::build_activity(&*conn, m.clone()), post.id, true, true);
+                }
+                for m in old_mentions.iter().filter(|m| !User::get(&conn, m.mentioned_id).map(|u| mentions.contains(&u.get_fqn(&conn))).unwrap_or(false)) {
+                    m.delete(&conn);
                 }
             }
 

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -210,37 +210,13 @@ fn update(blog: String, slug: String, user: User, conn: DbConn, data: LenientFor
                 post.update_mentions(&conn, mentions.into_iter().map(|m| Mention::build_activity(&conn, m)).collect());
             }
 
-            let old_tags = Tag::for_post(&*conn, post.id).into_iter().collect::<Vec<_>>();
-            let old_non_hashtags = old_tags.iter().filter_map(|tag| if !tag.is_hashtag {Some(tag.tag.clone())} else {None}).collect();
-            let old_hashtags = old_tags.iter().filter_map(|tag| if tag.is_hashtag {Some(tag.tag.clone())} else {None}).collect();
+            let tags = form.tags.split(",").map(|t| t.trim().to_camel_case()).filter(|t| t.len() > 0)
+                .collect::<HashSet<_>>().into_iter().map(|t| Tag::build_activity(&conn, t)).collect::<Vec<_>>();
+            post.update_tags(&conn, tags);
 
-            let tags = form.tags.split(",").map(|t| t.trim().to_camel_case()).filter(|t| t.len() > 0).collect::<HashSet<_>>();
-            for tag in tags.difference(&old_non_hashtags) {
-                Tag::insert(&*conn, NewTag {
-                    tag: tag.clone(),
-                    is_hashtag: false,
-                    post_id: post.id
-                });
-            }
-            for ot in old_tags.iter() {
-                if !tags.contains(&ot.tag) && !ot.is_hashtag {
-                    ot.delete(&conn);
-                }
-            }
-
-            let hashtags = hashtags.into_iter().map(|h| h.to_camel_case()).collect::<HashSet<_>>();
-            for hashtag in hashtags.difference(&old_hashtags) {
-                Tag::insert(&*conn, NewTag {
-                    tag: hashtag.clone(),
-                    is_hashtag: true,
-                    post_id: post.id,
-                });
-            }
-            for ot in old_tags {
-                if !hashtags.contains(&ot.tag) && ot.is_hashtag {
-                    ot.delete(&conn);
-                }
-            }
+            let hashtags = hashtags.into_iter().map(|h| h.to_camel_case()).collect::<HashSet<_>>()
+                .into_iter().map(|t| Tag::build_activity(&conn, t)).collect::<Vec<_>>();
+            post.update_tags(&conn, hashtags);
 
             if post.published {
                 let act = post.update_activity(&*conn);


### PR DESCRIPTION
Initially this was supposed to only concern tags, but I got a bit out of tracks

- [x] move to set to dedup mentions and tags
- [x] difference tags and hashtags remotely (fix #284)
- [x] delete (hash)tags remotely on post edition
- [x] add new (hash)tags remotely on post edition
- [x] delete mentions locally on post deletion 
- [x] delete mentions remotely on post deletion 
- [x] delete old mentions locally on post edition
- [x] delete old mentions remotely on post edition
- [x] create new mentions locally on post edition
- [x] create new mentions remotely on post edition