### PR TITLE
Correct Gentoo emerge instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -49,10 +49,10 @@ On **Gentoo**:
 emerge --sync
 
 # If you want PostgreSQL
-emerge -av postgresql eselect-postgresql gettext && emerge --ask dev-vcs/git
+emerge -avu dev-db/postgresql dev-vcs/git sys-devel/gettext
 
 # If you want SQlite
-emerge -av gettext && emerge --ask dev-vcs/git && emerge -pv sqlite3 libsqlite3-dev
+emerge -avu dev-db/sqlite dev-vcs/git sys-devel/gettext
 ```
 
 On **Mac OS X**, with [Homebrew](https://brew.sh/):


### PR DESCRIPTION
Emerge doesn't care what order the packages are given; it'll figure out the correct build order and pull in the proper dependencies. Adding the -u switch will only perform the emerge if the package is not yet installed or needs to be updated. This avoids wasting time performing an emerge on something that has already been emerged.

While harmless, it is unnecessary to explicitly include eselect-postgresql in the list as the dev-db/postgresql ebuilds declare it as a dependency. There is no "sqlite3" or "libsqlite3-dev" ebuilds, so that command would fail.