### PR TITLE
Decode unfollow activities in inbox properly

### DIFF
--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1,4 +1,15 @@
-use activitypub::{activity::{Announce, Create, Delete, Like, Undo, Update}, object::Tombstone};
+use activitypub::{
+    activity::{
+        Announce,
+        Create,
+        Delete,
+        Follow as FollowAct,
+        Like,
+        Undo,
+        Update
+    },
+    object::Tombstone
+};
 use failure::Error;
 use serde_json;
 
@@ -57,7 +68,7 @@ pub trait Inbox {
                                 Ok(())
                             },
                             "Follow" => {
-                                Follow::delete_id(act.undo_props.object_object::<Like>()?.object_props.id_string()?, actor_id.into(), conn);
+                                Follow::delete_id(act.undo_props.object_object::<FollowAct>()?.object_props.id_string()?, actor_id.into(), conn);
                                 Ok(())
                             }
                             _ => Err(InboxError::CantUndo)?


### PR DESCRIPTION
Actually it tried to decode `Follow` activity object referenced by `Undo` activity with `Like` type, surely a failed copy-and-paste but it made the whole thing unable to handle unfollow request correctly.

(Also formatted a bit imports block, like the one following just after)