### PR TITLE
i18n: Add Japanese translation

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -6,3 +6,4 @@ nb
 gl
 it
 ru
+ja

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,601 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: plume\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-15 16:33-0700\n"
+"PO-Revision-Date: 2018-12-03 21:52+0900\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>\n"
+"Language-Team: \n"
+"X-Generator: Poedit 2.2\n"
+
+msgid "Latest articles"
+msgstr "最新記事"
+
+msgid "No posts to see here yet."
+msgstr "ここにはまだ表示できる投稿がありません。"
+
+msgid "New article"
+msgstr "新しい記事"
+
+msgid "New blog"
+msgstr "新しいブログ"
+
+msgid "Create a blog"
+msgstr "ブログを作成"
+
+msgid "Title"
+msgstr "タイトル"
+
+msgid "Create blog"
+msgstr "ブログを作成"
+
+msgid "Comment \"{{ post }}\""
+msgstr "\"{{ post }}\" にコメント"
+
+msgid "Content"
+msgstr "コメント"
+
+msgid "Submit comment"
+msgstr "コメントを保存"
+
+msgid "Something broke on our side."
+msgstr "サーバー側で何らかの問題が発生しました。"
+
+msgid "Sorry about that. If you think this is a bug, please report it."
+msgstr "申し訳ありません。これがバグだと思われる場合は、問題を報告してください。"
+
+msgid "Configuration"
+msgstr "設定"
+
+msgid "Configure your instance"
+msgstr "インスタンスを設定"
+
+msgid "Name"
+msgstr "名前"
+
+msgid "Let&#x27;s go!"
+msgstr "開始しましょう！"
+
+msgid "Welcome to {{ instance_name | escape }}"
+msgstr "{{ instance_name | escape }} へようこそ"
+
+msgid "Notifications"
+msgstr "通知"
+
+msgid "Written by {{ link_1 }}{{ url }}{{ link_2 }}{{ name | escape }}{{ link_3 }}"
+msgstr "{{ link_1 }}{{ url }}{{ link_2 }}{{ name | escape }}{{ link_3 }} さんが投稿"
+
+msgid "This article is under the {{ license }} license."
+msgstr "この記事は {{ license }} ライセンスの元で公開されています。"
+
+msgid "One like"
+msgid_plural "{{ count }} likes"
+msgstr[0] "{{ count }} いいね"
+
+msgid "I don&#x27;t like this anymore"
+msgstr "もうこれにいいねしません"
+
+msgid "Add yours"
+msgstr "いいねする"
+
+msgid "One Boost"
+msgid_plural "{{ count }} Boosts"
+msgstr[0] "{{ count }} ブースト"
+
+msgid "I don&#x27;t want to boost this anymore"
+msgstr "もうこれをブーストしたくありません"
+
+msgid "Boost"
+msgstr "ブースト"
+
+msgid "Comments"
+msgstr "コメント"
+
+msgid "Respond"
+msgstr "返信"
+
+msgid "Comment"
+msgstr "コメント"
+
+msgid "New post"
+msgstr "新しい記事"
+
+msgid "Create a post"
+msgstr "記事を作成"
+
+msgid "Publish"
+msgstr "公開"
+
+msgid "Login"
+msgstr "ログイン"
+
+msgid "Username or email"
+msgstr "ユーザー名またはメールアドレス"
+
+msgid "Password"
+msgstr "パスワード"
+
+msgid "Dashboard"
+msgstr "ダッシュボード"
+
+msgid "Your Dashboard"
+msgstr "自分のダッシュボード"
+
+msgid "Your Blogs"
+msgstr "自分のブログ"
+
+msgid "You don&#x27;t have any blog yet. Create your own, or ask to join one."
+msgstr "まだブログを開設していません。ご自身のブログを開設するか、他のブログに参加するようにお願いしてください。"
+
+msgid "Start a new blog"
+msgstr "新しいブログを開始"
+
+msgid "Admin"
+msgstr "管理者"
+
+msgid "It is you"
+msgstr "自分"
+
+msgid "Edit your profile"
+msgstr "自分のプロフィールを編集"
+
+msgid "Open on {{ instance_url }}"
+msgstr "{{ instance_url }} で開く"
+
+msgid "Follow"
+msgstr "フォロー"
+
+msgid "Unfollow"
+msgstr "フォロー解除"
+
+msgid "Recently boosted"
+msgstr "最近ブーストしたもの"
+
+msgid "One follower"
+msgid_plural "{{ count }} followers"
+msgstr[0] "{{ count }} フォロワー"
+
+msgid "Edit your account"
+msgstr "自分のアカウントを編集"
+
+msgid "Your Profile"
+msgstr "自分のプロフィール"
+
+msgid "Display Name"
+msgstr "表示名"
+
+msgid "Email"
+msgstr "メールアドレス"
+
+msgid "Summary"
+msgstr "要約"
+
+msgid "Update account"
+msgstr "アカウントをアップデート"
+
+msgid "{{ name | escape }}'s followers"
+msgstr "{{ name | escape }} のフォロワー"
+
+msgid "Followers"
+msgstr "フォロワー"
+
+msgid "New Account"
+msgstr "新しいアカウント"
+
+msgid "Create an account"
+msgstr "アカウントを作成"
+
+msgid "Username"
+msgstr "ユーザー名"
+
+msgid "Password confirmation"
+msgstr "パスワードの確認"
+
+msgid "Create account"
+msgstr "アカウントを作成"
+
+msgid "Plume"
+msgstr "Plume"
+
+msgid "Menu"
+msgstr "メニュー"
+
+msgid "My account"
+msgstr "自分のアカウント"
+
+msgid "Log Out"
+msgstr "ログアウト"
+
+msgid "Log In"
+msgstr "ログイン"
+
+msgid "Register"
+msgstr "登録"
+
+msgid "You need to be logged in order to create a new blog"
+msgstr "新しいブログを作成するにはログインする必要があります"
+
+msgid "You need to be logged in order to post a comment"
+msgstr "コメントを投稿するにはログインする必要があります"
+
+msgid "You need to be logged in order to like a post"
+msgstr "投稿をいいねするにはログインする必要があります"
+
+msgid "You need to be logged in order to see your notifications"
+msgstr "通知を表示するにはログインする必要があります"
+
+msgid "You need to be logged in order to write a new post"
+msgstr "新しい記事を書くにはログインする必要があります"
+
+msgid "You need to be logged in order to boost a post"
+msgstr "投稿をブーストするにはログインする必要があります"
+
+msgid "Invalid username or password"
+msgstr "ユーザー名またはパスワードが間違っています"
+
+msgid "You need to be logged in order to access your dashboard"
+msgstr "ダッシュボードにアクセスするにはログインする必要があります"
+
+msgid "You need to be logged in order to follow someone"
+msgstr "他の人をフォローするにはログインする必要があります"
+
+msgid "You need to be logged in order to edit your profile"
+msgstr "自分のプロフィールを編集するにはログインする必要があります"
+
+msgid "By {{ link_1 }}{{ link_2 }}{{ link_3 }}{{ name | escape }}{{ link_4 }}"
+msgstr "{{ link_1 }}{{ link_2 }}{{ link_3 }}{{ name | escape }}{{ link_4 }} が投稿"
+
+msgid "{{ data }} boosted your article"
+msgstr "{{ data }} があなたの記事をブーストしました"
+
+msgid "{{ data }} started following you"
+msgstr "{{ data }} があなたのフォローを開始しました"
+
+msgid "{{ data }} liked your article"
+msgstr "{{ data }} があなたの記事をいいねしました"
+
+msgid "{{ data }} commented your article"
+msgstr "{{ data }} があなたの記事にコメントしました"
+
+msgid "We couldn&#x27;t find this page."
+msgstr "このページを見つけられませんでした。"
+
+msgid "The link that led you here may be broken."
+msgstr "このリンクは切れている可能性があります。"
+
+msgid "You are not authorized."
+msgstr "認証されていません。"
+
+msgid "You are not author in this blog."
+msgstr "あなたはこのブログの作者ではありません。"
+
+msgid "{{ data }} mentioned you."
+msgstr "{{ data }} があなたをメンションしました。"
+
+msgid "Your comment"
+msgstr "あなたのコメント"
+
+msgid "Unknown error"
+msgstr "不明なエラー"
+
+msgid "Invalid name"
+msgstr "無効な名前"
+
+msgid "A blog with the same name already exists."
+msgstr "同じ名前のブログがすでに存在します。"
+
+msgid "Your comment can't be empty"
+msgstr "コメントは空にできません"
+
+msgid "A post with the same title already exists."
+msgstr "同じタイトルの投稿がすでに存在します。"
+
+msgid "We need an email or a username to identify you"
+msgstr "あなたを識別するために、メールアドレスかユーザー名が必要です"
+
+msgid "Your password can't be empty"
+msgstr "パスワードは空にできません"
+
+msgid "Passwords are not matching"
+msgstr "パスワードが一致しません"
+
+msgid "Username can't be empty"
+msgstr "ユーザー名は空にできません"
+
+msgid "Invalid email"
+msgstr "無効なメールアドレス"
+
+msgid "Password should be at least 8 characters long"
+msgstr "パスワードは最低 8 文字にするべきです"
+
+msgid "One author in this blog: "
+msgid_plural "{{ count }} authors in this blog: "
+msgstr[0] "ブログに {{ count }} 人の作成者がいます: "
+
+msgid "Login or use your Fediverse account to interact with this article"
+msgstr "この記事と関わるにはログインするか Fediverse アカウントを使用してください"
+
+msgid "Optional"
+msgstr "省略可"
+
+msgid "One article in this blog"
+msgid_plural "{{ count }} articles in this blog"
+msgstr[0] "ブログ内に {{ count }} 件の記事"
+
+msgid "Previous page"
+msgstr "前のページ"
+
+msgid "Next page"
+msgstr "次のページ"
+
+msgid "{{ user }} mentioned you."
+msgstr "{{ user }} があなたをメンションしました。"
+
+msgid "{{ user }} commented your article."
+msgstr "{{ user }} があなたの記事にコメントしました。"
+
+msgid "{{ user }} is now following you."
+msgstr "{{ user }} はあなたをフォローしています。"
+
+msgid "{{ user }} liked your article."
+msgstr "{{ user }} があなたの記事にいいねしました。"
+
+msgid "{{ user }} boosted your article."
+msgstr "{{ user }} があなたの記事をブーストしました。"
+
+msgid "Source code"
+msgstr "ソースコード"
+
+msgid "Matrix room"
+msgstr "Matrix　ルーム"
+
+msgid "Administration"
+msgstr "管理"
+
+msgid "Instance settings"
+msgstr "インスタンスの設定"
+
+msgid "Allow anyone to register"
+msgstr "不特定多数に登録を許可"
+
+msgid "Short description"
+msgstr "短い説明"
+
+msgid "Markdown is supported"
+msgstr "Markdown がサポートされています"
+
+msgid "Long description"
+msgstr "長い説明"
+
+msgid "Default license"
+msgstr "デフォルトのライセンス"
+
+msgid "Save settings"
+msgstr "設定を保存"
+
+msgid "No comments yet. Be the first to react!"
+msgstr "コメントがまだありません。最初のコメントを書きましょう！"
+
+msgid "About this instance"
+msgstr "このインスタンスについて"
+
+msgid "What is Plume?"
+msgstr "Plume とは？"
+
+msgid "Plume is a decentralized blogging engine."
+msgstr "Plume は分散型ブログエンジンです。"
+
+msgid "Authors can manage various blogs from an unique website."
+msgstr "作成者は、ある固有の Web サイトから、さまざまなブログを管理できます。"
+
+msgid "Articles are also visible on other Plume websites, and you can interact with them directly from other platforms like Mastodon."
+msgstr "記事は他の Plume Web サイトからも閲覧可能であり、Mastdon のように他のプラットフォームから直接記事と関わることができます。"
+
+msgid "Create your account"
+msgstr "アカウントを作成"
+
+msgid "About {{ instance_name }}"
+msgstr "{{ instance_name }} について"
+
+msgid "Home to"
+msgstr "登録者数"
+
+msgid "people"
+msgstr "人"
+
+msgid "Who wrote"
+msgstr "投稿記事数"
+
+msgid "articles"
+msgstr "件"
+
+msgid "Read the detailed rules"
+msgstr "詳細な規則を読む"
+
+msgid "Delete this article"
+msgstr "この記事を削除"
+
+msgid "Delete this blog"
+msgstr "このブログを削除"
+
+msgid "And connected to"
+msgstr "他のインスタンスからの接続数"
+
+msgid "other instances"
+msgstr "件"
+
+msgid "Administred by"
+msgstr "管理者"
+
+msgid "Runs Plume {{ version }}"
+msgstr "Plume {{ version }} を実行中"
+
+msgid "Your media"
+msgstr "メディア"
+
+msgid "Go to your gallery"
+msgstr "ギャラリーを参照"
+
+msgid "{{ name}}'s avatar'"
+msgstr "{{ name}} のアバター"
+
+msgid "Media details"
+msgstr "メディアの詳細"
+
+msgid "Go back to the gallery"
+msgstr "ライブラリに戻る"
+
+msgid "Markdown code"
+msgstr "Markdown コード"
+
+msgid "Copy it in your articles to insert this media."
+msgstr "このメディアを記事に挿入するには、自分の記事にコピーしてください。"
+
+msgid "Use as avatar"
+msgstr "アバターとして使う"
+
+msgid "Delete"
+msgstr "削除"
+
+msgid "Upload"
+msgstr "アップロード"
+
+msgid "You don't have any media yet."
+msgstr "メディアがまだありません。"
+
+msgid "Media upload"
+msgstr "メディアのアップロード"
+
+msgid "Description"
+msgstr "説明"
+
+msgid "Content warning"
+msgstr "コンテンツの警告"
+
+msgid "File"
+msgstr "ファイル"
+
+msgid "Send"
+msgstr "送信"
+
+msgid "Sorry, but registrations are closed on this instance. Try to find another one"
+msgstr "申し訳ありませんが、このインスタンスでは登録者は限定されています。別のインスタンスをお探しください"
+
+msgid "Subtitle"
+msgstr "サブタイトル"
+
+msgid "Login to like"
+msgstr "いいねするにはログインしてください"
+
+msgid "Login to boost"
+msgstr "ブーストするにはログインしてください"
+
+msgid "Your feed"
+msgstr "自分のフィード"
+
+msgid "Federated feed"
+msgstr "全インスタンスのフィード"
+
+msgid "Local feed"
+msgstr "このインスタンスのフィード"
+
+msgid "Nothing to see here yet. Try to follow more people."
+msgstr "ここにはまだ表示できるものがありません。他の人をもっとフォローしてみてください。"
+
+msgid "Articles"
+msgstr "記事"
+
+msgid "All the articles of the Fediverse"
+msgstr "Fediverse のすべての記事"
+
+msgid "Articles from {{ instance.name }}"
+msgstr "{{ instance.name }} の記事"
+
+msgid "View all"
+msgstr "すべて表示"
+
+msgid "Articles tagged \"{{ tag }}\""
+msgstr "\"{{ tag }}\" タグの記事"
+
+msgid "Edit"
+msgstr "編集"
+
+msgid "Edit {{ post }}"
+msgstr "{{ post }} を編集"
+
+msgid "Update"
+msgstr "アップデート"
+
+msgid "We couldn't find this page."
+msgstr "このページは見つかりませんでした。"
+
+msgid "Invalid CSRF token."
+msgstr "無効な CSRF トークンです。"
+
+msgid "Something is wrong with your CSRF token. Make sure cookies are enabled in you browser, and try reloading this page. If you continue to see this error message, please report it."
+msgstr "ご自身の CSRF トークンにおいて問題が発生しました。お使いのブラウザーで Cookie　が有効になっていることを確認して、このページを再読み込みしてみてください。このエラーメッセージが表示され続けた場合、問題を報告してください。"
+
+msgid "Administration of {{ instance.name }}"
+msgstr "{{ instance.name }} の管理"
+
+msgid "Instances"
+msgstr "インスタンス"
+
+msgid "Unblock"
+msgstr "ブロック解除"
+
+msgid "Block"
+msgstr "ブロック"
+
+msgid "Ban"
+msgstr "禁止"
+
+msgid "Useful for visually impaired people and licensing"
+msgstr "視覚的に障害のある方や認可の際に便利です"
+
+msgid "Let it empty if there is none"
+msgstr "不要な場合は空にしてください"
+
+msgid "Draft"
+msgstr "下書き"
+
+msgid "This is a draft, don't publish it yet."
+msgstr "これは下書きなので、まだ公開しないでください。"
+
+msgid "Update or publish"
+msgstr "更新または公開"
+
+msgid "Your Drafts"
+msgstr "下書き"
+
+msgid "Danger zone"
+msgstr "危険"
+
+msgid "Be very careful, any action taken here can't be cancelled."
+msgstr "十分ご注意ください。ここで行ったすべての操作は取り消しできません。"
+
+msgid "Delete your account"
+msgstr "アカウントを削除"
+
+msgid "Sorry, but as an admin, you can't leave your instance."
+msgstr "申し訳ありませんが、管理者として、自分のインスタンスを離脱できません。"
+
+msgid "Users"
+msgstr "ユーザー"
+
+msgid "This post isn't published yet."
+msgstr "この投稿はまだ公開されていません。"
+
+msgid "There is currently no article with that tag"
+msgstr "そのタグのある記事は現在ありません"
+
+msgid "Illustration"
+msgstr "図"
+
+msgid "None"
+msgstr "なし"


### PR DESCRIPTION
Browsing the Demo instance, I sometimes found Japanese articles. So I decided to translate Plume into Japanese.
