### PR TITLE
License federation

### DIFF
--- a/plume-common/src/activity_pub/mod.rs
+++ b/plume-common/src/activity_pub/mod.rs
@@ -220,3 +220,12 @@ pub struct Source {
 }
 
 impl Object for Source {}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Properties)]
+#[serde(rename_all = "camelCase")]
+pub struct Licensed {
+    #[activitystreams(concrete(String), functional)]
+    pub license: Option<serde_json::Value>,
+}
+
+impl Object for Licensed {}

--- a/po/de.po
+++ b/po/de.po
@@ -609,6 +609,13 @@ msgstr "Administration"
 msgid "None"
 msgstr ""
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Falls es dies nicht gibt, lass es leer"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Heimat von"
 

--- a/po/en.po
+++ b/po/en.po
@@ -593,3 +593,9 @@ msgstr ""
 
 msgid "None"
 msgstr ""
+
+msgid "Let it empty reserve all rights"
+msgstr ""
+
+msgid "All rights reserved."
+msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -609,3 +609,10 @@ msgstr "Illustration"
 
 msgid "None"
 msgstr "Aucun"
+
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Laisser vide s’il n’y en a pas"
+
+msgid "All rights reserved."
+msgstr ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -600,6 +600,13 @@ msgstr "Administración"
 msgid "None"
 msgstr ""
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Deixar baldeiro si non hai ningunha"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Fogar de"
 

--- a/po/it.po
+++ b/po/it.po
@@ -603,6 +603,13 @@ msgstr "Amministrazione"
 msgid "None"
 msgstr ""
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Lascialo vuoto se non è presente nessuno"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Casa di"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -595,6 +595,13 @@ msgstr "図"
 msgid "None"
 msgstr "なし"
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "不要な場合は空にしてください"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Welcome to {{ instance_name | escape }}"
 #~ msgstr "{{ instance_name | escape }} へようこそ"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -615,6 +615,12 @@ msgstr "Administrasjon"
 msgid "None"
 msgstr ""
 
+msgid "Let it empty reserve all rights"
+msgstr ""
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Hjem for"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -609,6 +609,13 @@ msgstr "Ilustracja"
 msgid "None"
 msgstr "Brak"
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Pozostaw puste, jeżeli niepotrzebne"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Dom dla"
 

--- a/po/plume.pot
+++ b/po/plume.pot
@@ -579,3 +579,9 @@ msgstr ""
 
 msgid "None"
 msgstr ""
+
+msgid "Let it empty reserve all rights"
+msgstr ""
+
+msgid "All rights reserved."
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -620,6 +620,13 @@ msgstr "Иллюстрация"
 msgid "None"
 msgstr "Нет"
 
+#, fuzzy
+msgid "Let it empty reserve all rights"
+msgstr "Оставьте пустым если нет"
+
+msgid "All rights reserved."
+msgstr ""
+
 #~ msgid "Home to"
 #~ msgstr "Дом для"
 

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -1,4 +1,3 @@
-use activitypub::object::Article;
 use chrono::Utc;
 use heck::{CamelCase, KebabCase};
 use rocket::request::LenientForm;
@@ -89,7 +88,7 @@ pub fn details_response(blog: String, slug: String, conn: DbConn, user: Option<U
 }
 
 #[get("/~/<blog>/<slug>", rank = 3)]
-pub fn activity_details(blog: String, slug: String, conn: DbConn, _ap: ApRequest) -> Result<ActivityStream<Article>, Option<String>> {
+pub fn activity_details(blog: String, slug: String, conn: DbConn, _ap: ApRequest) -> Result<ActivityStream<LicensedArticle>, Option<String>> {
     let blog = Blog::find_by_fqn(&*conn, &blog).ok_or(None)?;
     let post = Post::find_by_slug(&*conn, &slug, blog.id).ok_or(None)?;
     if post.published {

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -1,4 +1,4 @@
-use activitypub::{activity::Create, collection::OrderedCollection, object::Article};
+use activitypub::{activity::Create, collection::OrderedCollection};
 use atom_syndication::{Entry, FeedBuilder};
 use rocket::{
     http::{ContentType, Cookies},
@@ -18,7 +18,7 @@ use plume_common::activity_pub::{
 };
 use plume_common::utils;
 use plume_models::{
-    blogs::Blog, db_conn::DbConn, follows, headers::Headers, instance::Instance, posts::Post,
+    blogs::Blog, db_conn::DbConn, follows, headers::Headers, instance::Instance, posts::{LicensedArticle, Post},
     reshares::Reshare, users::*,
 };
 use routes::Page;
@@ -56,7 +56,7 @@ pub fn details(
         let searcher = searcher.clone();
         worker.execute(move || {
             for create_act in user_clone.fetch_outbox::<Create>() {
-                match create_act.create_props.object_object::<Article>() {
+                match create_act.create_props.object_object::<LicensedArticle>() {
                     Ok(article) => {
                         Post::from_activity(
                             &(&*fetch_articles_conn, &searcher),

--- a/templates/posts/details.rs.html
+++ b/templates/posts/details.rs.html
@@ -53,7 +53,13 @@
         @Html(&article.content)
     </article>
     <div class="article-meta">
-        <p>@i18n!(ctx.1, "This article is under the {0} license."; &article.license)</p>
+        <p>
+            @if article.license.is_empty() {
+                @i18n!(ctx.1, "All rights reserved."; &article.license)
+            } else {
+                @i18n!(ctx.1, "This article is under the {0} license."; &article.license)
+            }
+        </p>
         <ul class="tags">
             @for tag in tags {
                 @if !tag.is_hashtag {

--- a/templates/posts/new.rs.html
+++ b/templates/posts/new.rs.html
@@ -8,7 +8,7 @@
 @use routes::posts::NewPostForm;
 @use routes::*;
 
-@(ctx: BaseContext, blog: Blog, editing: bool, form: &NewPostForm, is_draft: bool, article: Option<Post>, errors: ValidationErrors, default_license: String, medias: Vec<Media>)
+@(ctx: BaseContext, blog: Blog, editing: bool, form: &NewPostForm, is_draft: bool, article: Option<Post>, errors: ValidationErrors, medias: Vec<Media>)
 
 @:base(ctx, &i18n!(ctx.1, if editing { "Edit {0}" } else { "New post" }; &form.title), {}, {}, {
     <h1>
@@ -35,7 +35,7 @@
 
         @input!(ctx.1, tags (optional text), "Tags, separated by commas", form, errors.clone(), "")
 
-        @input!(ctx.1, license (optional text), "License", &i18n!(ctx.1, "Default license will be {0}"; &default_license), form, errors, "")
+        @input!(ctx.1, license (optional text), "License", "Let it empty reserve all rights", form, errors, "")
 
         <label for="cover">@i18n!(ctx.1, "Illustration")<small>@i18n!(ctx.1, "Optional")</small></label>
         <select id="cover" name="cover">


### PR DESCRIPTION
Fixes #259 

I decided not to follow what Peertube was doing, and to use a simple `license` field with the name of the license, because their system is not flexible enough IMO, each AP implementation would have to keep the same list of licenses, and it wouldn't allow any other license outside of that.

A bit unrelated, but I also made it possible to have no specific license to keep all your rights on what you wrote. The license field will now be pre-filled with the default license when creating a post, and emptying it will display "All rights reserved" instead of the name of the license.