### PR TITLE
Add a space between u-url class and href

### DIFF
--- a/templates/partials/post_card.rs.html
+++ b/templates/partials/post_card.rs.html
@@ -8,7 +8,7 @@
     @if article.cover_id.is_some() {
         <div class="cover" style="background-image: url('@Html(article.cover_url(ctx.0).unwrap_or_default())')"></div>
     }
-    <h3 class="p-name"><a class="u-url"href="@uri!(posts::details: blog = article.get_blog(ctx.0).get_fqn(ctx.0), slug = &article.slug)">@article.title</a></h3>
+    <h3 class="p-name"><a class="u-url" href="@uri!(posts::details: blog = article.get_blog(ctx.0).get_fqn(ctx.0), slug = &article.slug)">@article.title</a></h3>
     <main>
         <p class="p-summary">@article.subtitle</p>
     </main>


### PR DESCRIPTION
There's a missing space, which probably causes the h-feed not to parse.
You can always use http://xray.p3k.io/ to validate the microformats on a page.

e.g. http://xray.p3k.io/parse?url=https%3A%2F%2Fbaptiste.gelez.xyz%2F%7E%2FFederationTesting%2Fplume-and-the-indie-web&pretty=true is fine, so that's good!

However, the h-feed isn't parsing right - http://xray.p3k.io/parse?expect=feed&url=https%3A%2F%2Fbaptiste.gelez.xyz%2F%40%2F0x1C3B00DA&pretty=true (you can always add 'expect=feed' to the get params if you are really sure it needs to be a feed)