### PR TITLE
Allow for comment deletion

### DIFF
--- a/plume-models/src/comments.rs
+++ b/plume-models/src/comments.rs
@@ -285,12 +285,11 @@ impl<'a> Deletable<Connection, Delete> for Comment {
             .expect("Comment::delete: DB error could not update other comments");
         diesel::delete(self)
             .execute(conn)
-            .expect("Post::delete: DB error");
+            .expect("Comment::delete: DB error");
         act
     }
 
     fn delete_id(id: &str, actor_id: &str, conn: &Connection) {
-        println!("Deleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\n");
         let actor = User::find_by_ap_url(conn, actor_id);
         let comment = Comment::find_by_ap_url(conn, id);
         if let Some(comment) = comment.filter(|c| c.author_id == actor.unwrap().id) {

--- a/plume-models/src/comments.rs
+++ b/plume-models/src/comments.rs
@@ -1,4 +1,4 @@
-use activitypub::{activity::Create, link, object::Note};
+use activitypub::{activity::{Create, Delete}, link, object::{Note, Tombstone}};
 use chrono::{self, NaiveDateTime};
 use diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
 use serde_json;
@@ -7,7 +7,7 @@ use instance::Instance;
 use mentions::Mention;
 use notifications::*;
 use plume_common::activity_pub::{
-    inbox::{FromActivity, Notify},
+    inbox::{FromActivity, Notify, Deletable},
     Id, IntoId, PUBLIC_VISIBILTY,
 };
 use plume_common::utils;
@@ -248,6 +248,53 @@ impl Notify<Connection> for Comment {
                     user_id: author.id,
                 },
             );
+        }
+    }
+}
+
+
+impl<'a> Deletable<Connection, Delete> for Comment {
+    fn delete(&self, conn: &Connection) -> Delete {
+        let mut act = Delete::default();
+        act.delete_props
+            .set_actor_link(self.get_author(conn).into_id())
+            .expect("Comment::delete: actor error");
+
+        let mut tombstone = Tombstone::default();
+        tombstone
+            .object_props
+            .set_id_string(self.ap_url.clone().expect("Comment::delete: no ap_url"))
+            .expect("Comment::delete: object.id error");
+        act.delete_props
+            .set_object_object(tombstone)
+            .expect("Comment::delete: object error");
+
+        act.object_props
+            .set_id_string(format!("{}#delete", self.ap_url.clone().unwrap()))
+            .expect("Comment::delete: id error");
+        act.object_props
+            .set_to_link_vec(vec![Id::new(PUBLIC_VISIBILTY)])
+            .expect("Comment::delete: to error");
+
+        for m in Mention::list_for_comment(&conn, self.id) {
+            m.delete(conn);
+        }
+        diesel::update(comments::table).filter(comments::in_response_to_id.eq(self.id))
+            .set(comments::in_response_to_id.eq(self.in_response_to_id))
+            .execute(conn)
+            .expect("Comment::delete: DB error could not update other comments");
+        diesel::delete(self)
+            .execute(conn)
+            .expect("Post::delete: DB error");
+        act
+    }
+
+    fn delete_id(id: &str, actor_id: &str, conn: &Connection) {
+        println!("Deleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\nDeleting comment\n");
+        let actor = User::find_by_ap_url(conn, actor_id);
+        let comment = Comment::find_by_ap_url(conn, id);
+        if let Some(comment) = comment.filter(|c| c.author_id == actor.unwrap().id) {
+            comment.delete(conn);
         }
     }
 }

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -55,6 +55,14 @@ pub trait Inbox {
                         actor_id.as_ref(),
                         &(conn, searcher),
                     );
+                    Comment::delete_id(
+                        &act.delete_props
+                            .object_object::<Tombstone>()?
+                            .object_props
+                            .id_string()?,
+                        actor_id.as_ref(),
+                        conn,
+                    );
                     Ok(())
                 }
                 "Follow" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn main() {
             routes::blogs::atom_feed,
 
             routes::comments::create,
+            routes::comments::delete,
             routes::comments::activity_pub,
 
             routes::instance::index,

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -202,17 +202,18 @@ main .article-meta {
     }
 
     // New comment form
-    form input[type="submit"] {
+    > form input[type="submit"] {
       font-size: 1em;
     }
 
-    // Response button
-    a.button {
+    // Response/delete buttons
+    a.button, form.inline, form.inline input {
      	display: inline-block;
      	padding: 0;
      	background: none;
      	color: $black;
      	border: none;
+     	margin-right: 2em;
 
      	&::before {
      	  color: $purple;

--- a/static/css/feather.css
+++ b/static/css/feather.css
@@ -17,7 +17,7 @@
 	fill: none;
 }
 
-.icon {
+.icon:before {
 	font-family: "Feather";
 	speak: none;
 	font-style: normal;

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -29,10 +29,9 @@
     </div>
     <a class="button icon icon-message-circle" href="?responding_to=@comm.id">@i18n!(ctx.1, "Respond")</a>
     @if ctx.2.clone().map(|u| u.id == author.id).unwrap_or(false) {
-        &mdash;
-        <form class="inline" method="post" action="@uri!(comments::delete: blog = blog, slug = slug, id = comm.id)">
+        <form class="inline icon icon-trash" method="post" action="@uri!(comments::delete: blog = blog, slug = slug, id = comm.id)">
             <input onclick="return confirm('Are you sure you?')" type="submit" value="@i18n!(ctx.1, "Delete this comment")">
-	</form>
+	    </form>
     }
     @for res in comm.get_responses(ctx.0) {
         @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u), blog, slug)

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -3,14 +3,14 @@
 @use plume_models::users::User;
 @use routes::*;
 
-@(ctx: BaseContext, comm: &Comment, author: User, in_reply_to: Option<&str>)
+@(ctx: BaseContext, comm: &Comment, author: User, in_reply_to: Option<&str>, blog: &str, slug: &str)
 
 <div class="comment u-comment h-cite" id="comment-@comm.id">
     <a class="author u-author h-card" href="@uri!(user::details: name = author.get_fqn(ctx.0))">
         @avatar(ctx.0, &author, Size::Small, true, ctx.1)
         <span class="display-name p-name">@author.name(ctx.0)</span>
         <small>@author.get_fqn(ctx.0)</small>
-    </a>
+	    </a>
     @if let Some(ref ap_url) = comm.ap_url {
         <a class="u-url" href="@ap_url"></a>
     }
@@ -28,7 +28,13 @@
         }
     </div>
     <a class="button icon icon-message-circle" href="?responding_to=@comm.id">@i18n!(ctx.1, "Respond")</a>
+    @if ctx.2.clone().map(|u| u.id == author.id).unwrap_or(false) {
+        &mdash;
+        <form class="inline" method="post" action="@uri!(comments::delete: blog = blog, slug = slug, id = comm.id)">
+            <input onclick="return confirm('Are you sure you?')" type="submit" value="@i18n!(ctx.1, "Delete this comment")">
+	</form>
+    }
     @for res in comm.get_responses(ctx.0) {
-        @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u))
+        @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u), blog, slug)
     }
 </div>

--- a/templates/posts/details.rs.html
+++ b/templates/posts/details.rs.html
@@ -146,7 +146,7 @@
             @if !comments.is_empty() {
                 <div class="list">
                     @for comm in comments {
-                        @:comment(ctx, &comm, comm.get_author(ctx.0), Some(&article.ap_url))
+                        @:comment(ctx, &comm, comm.get_author(ctx.0), Some(&article.ap_url), &blog.get_fqn(ctx.0), &article.slug)
                     }
                 </div>
             } else {


### PR DESCRIPTION
Fix #224 

Current design is a bit terrible. I've tried things, only made it worse. If someone better than me at CSS could give it a try

This tries to conserve as much threads as possible, by re-linking comments to the parent of the one being deleted