### PR TITLE
Comment visibility

### DIFF
--- a/migrations/postgres/2018-12-17-221135_comment_visibility/down.sql
+++ b/migrations/postgres/2018-12-17-221135_comment_visibility/down.sql
@@ -1,0 +1,4 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE comments DROP COLUMN public_visibility;
+
+DROP TABLE comment_seers;

--- a/migrations/postgres/2018-12-17-221135_comment_visibility/up.sql
+++ b/migrations/postgres/2018-12-17-221135_comment_visibility/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+ALTER TABLE comments ADD public_visibility BOOLEAN NOT NULL DEFAULT 't';
+
+CREATE TABLE comment_seers (
+    id SERIAL PRIMARY KEY,
+    comment_id INTEGER REFERENCES comments(id) ON DELETE CASCADE NOT NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    UNIQUE (comment_id, user_id)
+)

--- a/migrations/sqlite/2018-12-17-221135_comment_visibility/down.sql
+++ b/migrations/sqlite/2018-12-17-221135_comment_visibility/down.sql
@@ -1,0 +1,18 @@
+-- This file should undo anything in `up.sql`
+CREATE TABLE comments2 (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    content TEXT NOT NULL DEFAULT '',
+    in_response_to_id INTEGER REFERENCES comments(id),
+    post_id INTEGER REFERENCES posts(id) ON DELETE CASCADE NOT NULL,
+    author_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    creation_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    ap_url VARCHAR,
+    sensitive BOOLEAN NOT NULL DEFAULT 'f',
+    spoiler_text TEXT NOT NULL DEFAULT ''
+);
+
+INSERT INTO comments2 SELECT id,content,in_response_to_id,post_id,author_id,creation_date,ap_url,sensitive,spoiler_text FROM comments;
+DROP TABLE comments;
+ALTER TABLE comments2 RENAME TO comments;
+
+DROP TABLE comment_seers;

--- a/migrations/sqlite/2018-12-17-221135_comment_visibility/up.sql
+++ b/migrations/sqlite/2018-12-17-221135_comment_visibility/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+ALTER TABLE comments ADD public_visibility BOOLEAN NOT NULL DEFAULT 't';
+
+CREATE TABLE comment_seers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    comment_id INTEGER REFERENCES comments(id) ON DELETE CASCADE NOT NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    UNIQUE (comment_id, user_id)
+)

--- a/plume-models/src/comment_seers.rs
+++ b/plume-models/src/comment_seers.rs
@@ -1,0 +1,32 @@
+use diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl};
+
+use comments::Comment;
+use schema::comment_seers;
+use users::User;
+use Connection;
+
+#[derive(Queryable, Serialize, Clone)]
+pub struct CommentSeers {
+    pub id: i32,
+    pub comment_id: i32,
+    pub user_id: i32,
+}
+
+#[derive(Insertable, Default)]
+#[table_name = "comment_seers"]
+pub struct NewCommentSeers {
+    pub comment_id: i32,
+    pub user_id: i32,
+}
+
+impl CommentSeers {
+    insert!(comment_seers, NewCommentSeers);
+
+    pub fn can_see(conn: &Connection, c: &Comment, u: &User) -> bool {
+        !comment_seers::table.filter(comment_seers::comment_id.eq(c.id))
+            .filter(comment_seers::user_id.eq(u.id))
+            .load::<CommentSeers>(conn)
+            .expect("Comment::get_responses: loading error")
+            .is_empty()
+    }
+}

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -250,6 +250,7 @@ pub mod apps;
 pub mod blog_authors;
 pub mod blogs;
 pub mod comments;
+pub mod comment_seers;
 pub mod db_conn;
 pub mod follows;
 pub mod headers;

--- a/plume-models/src/schema.rs
+++ b/plume-models/src/schema.rs
@@ -57,6 +57,15 @@ table! {
         ap_url -> Nullable<Varchar>,
         sensitive -> Bool,
         spoiler_text -> Text,
+        public_visibility -> Bool,
+    }
+}
+
+table! {
+    comment_seers (id) {
+        id -> Int4,
+        comment_id -> Int4,
+        user_id -> Int4,
     }
 }
 
@@ -201,6 +210,8 @@ joinable!(api_tokens -> users (user_id));
 joinable!(blog_authors -> blogs (blog_id));
 joinable!(blog_authors -> users (author_id));
 joinable!(blogs -> instances (instance_id));
+joinable!(comment_seers -> comments (comment_id));
+joinable!(comment_seers -> users (user_id));
 joinable!(comments -> posts (post_id));
 joinable!(comments -> users (author_id));
 joinable!(likes -> posts (post_id));
@@ -224,6 +235,7 @@ allow_tables_to_appear_in_same_query!(
     blog_authors,
     blogs,
     comments,
+    comment_seers,
     follows,
     instances,
     likes,

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -26,7 +26,7 @@ use rocket::{
     request::{self, FromRequest, Request},
 };
 use serde_json;
-use std::cmp::PartialEq;
+use std::{cmp::PartialEq, hash::{Hash, Hasher}};
 use url::Url;
 use webfinger::*;
 
@@ -900,6 +900,7 @@ impl IntoId for User {
     }
 }
 
+impl Eq for User {}
 impl Object for User {}
 impl Actor for User {}
 
@@ -953,6 +954,12 @@ impl Signer for User {
 impl PartialEq for User {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
+    }
+}
+
+impl Hash for User {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -43,7 +43,8 @@ pub fn create(blog_name: String, slug: String, form: LenientForm<NewCommentForm>
                 author_id: user.id,
                 ap_url: None,
                 sensitive: !form.warning.is_empty(),
-                spoiler_text: form.warning.clone()
+                spoiler_text: form.warning.clone(),
+                public_visibility: true
             }).update_ap_url(&*conn);
             let new_comment = comm.create_activity(&*conn);
 

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -5,7 +5,7 @@
 
 @(ctx: BaseContext, comm: &Comment, author: User, in_reply_to: Option<&str>)
 
-@if comm.public_visibility {
+@if ctx.2.as_ref().map(|u| comm.can_see(ctx.0 ,u)).unwrap_or(comm.public_visibility) {
 <div class="comment u-comment h-cite" id="comment-@comm.id">
     <a class="author u-author h-card" href="@uri!(user::details: name = author.get_fqn(ctx.0))">
         @avatar(ctx.0, &author, Size::Small, true, ctx.1)
@@ -29,10 +29,18 @@
         }
     </div>
     <a class="button icon icon-message-circle" href="?responding_to=@comm.id">@i18n!(ctx.1, "Respond")</a>
-} else {
-<div class="comment">
-}
     @for res in comm.get_responses(ctx.0) {
         @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u))
     }
 </div>
+} else {
+    @if let Some(responses) = Some(comm.get_responses(ctx.0)) {
+        @if !responses.is_empty() {
+<div class="comment">
+    @for res in comm.get_responses(ctx.0) {
+        @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u))
+    }
+</div>
+        }
+    }
+}

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -5,6 +5,7 @@
 
 @(ctx: BaseContext, comm: &Comment, author: User, in_reply_to: Option<&str>)
 
+@if comm.public_visibility {
 <div class="comment u-comment h-cite" id="comment-@comm.id">
     <a class="author u-author h-card" href="@uri!(user::details: name = author.get_fqn(ctx.0))">
         @avatar(ctx.0, &author, Size::Small, true, ctx.1)
@@ -28,6 +29,9 @@
         }
     </div>
     <a class="button icon icon-message-circle" href="?responding_to=@comm.id">@i18n!(ctx.1, "Respond")</a>
+} else {
+<div class="comment">
+}
     @for res in comm.get_responses(ctx.0) {
         @:comment(ctx, &res, res.get_author(ctx.0), comm.ap_url.as_ref().map(|u| &**u))
     }


### PR DESCRIPTION
Add some support for comment visibility, fix #217 

This add a new column to comment, denoting if they are public or not, and a new table linking private comments to those allowed to read them. There is currently no way to write a private comment from Plume.
Git is having a hard time what happened in Comment::from_activity, but most of it is just re-indentation because a new block was needed to please the borrow checker.
At this point only mentioned users can see private comments, even when posted as "follower only" or equivalent.

What should we do when someone isn't allowed to see a comment? Hide the whole thread, or just the comment? If hiding just the comment, should we mark there is a comment one can't see, but answers they can, or put other comments like if they answered to the same comment the hidden one do?