### PR TITLE
Support blind key rotation

### DIFF
--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -364,6 +364,10 @@ impl User {
                         .followers_string()?),
                     users::avatar_id.eq(avatar.map(|a| a.id)),
                     users::last_fetched_date.eq(Utc::now().naive_utc()),
+                    users::public_key.eq(json
+                        .custom_props
+                        .public_key_publickey()?
+                        .public_key_pem_string()?),
                 ))
                 .execute(conn)
                 .map(|_| ())

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -10,6 +10,7 @@ use plume_models::{
     admin::Admin,
     comments::Comment,
     db_conn::DbConn,
+    Error,
     headers::Headers,
     posts::Post,
     users::User,
@@ -180,16 +181,26 @@ pub fn ban(_admin: Admin, conn: DbConn, id: i32, searcher: Searcher) -> Result<R
 #[post("/inbox", data = "<data>")]
 pub fn shared_inbox(conn: DbConn, data: SignedJson<serde_json::Value>, headers: Headers, searcher: Searcher) -> Result<String, status::BadRequest<&'static str>> {
     let act = data.1.into_inner();
+    let sig = data.0;
 
     let activity = act.clone();
     let actor_id = activity["actor"].as_str()
         .or_else(|| activity["actor"]["id"].as_str()).ok_or(status::BadRequest(Some("Missing actor id for activity")))?;
 
     let actor = User::from_url(&conn, actor_id).expect("instance::shared_inbox: user error");
-    if !verify_http_headers(&actor, &headers.0, &data.0).is_secure() &&
+    if !verify_http_headers(&actor, &headers.0, &sig).is_secure() &&
         !act.clone().verify(&actor) {
-        println!("Rejected invalid activity supposedly from {}, with headers {:?}", actor.username, headers.0);
-        return Err(status::BadRequest(Some("Invalid signature")));
+        // maybe we just know an old key?
+        actor.refetch(&conn).and_then(|_| User::get(&conn, actor.id))
+            .and_then(|actor| if !verify_http_headers(&actor, &headers.0, &sig).is_secure() &&
+                      !act.clone().verify(&actor) {
+                          Ok(())
+                      } else {
+                          Err(Error::Signature)
+                      })
+            .map_err(|_| {
+                println!("Rejected invalid activity supposedly from {}, with headers {:?}", actor.username, headers.0);
+                status::BadRequest(Some("Invalid signature"))})?;
     }
 
     if Instance::is_blocked(&*conn, actor_id).map_err(|_| status::BadRequest(Some("Can't tell if instance is blocked")))? {

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -192,8 +192,8 @@ pub fn shared_inbox(conn: DbConn, data: SignedJson<serde_json::Value>, headers: 
         !act.clone().verify(&actor) {
         // maybe we just know an old key?
         actor.refetch(&conn).and_then(|_| User::get(&conn, actor.id))
-            .and_then(|actor| if !verify_http_headers(&actor, &headers.0, &sig).is_secure() &&
-                      !act.clone().verify(&actor) {
+            .and_then(|u| if verify_http_headers(&u, &headers.0, &sig).is_secure() ||
+                      act.clone().verify(&u) {
                           Ok(())
                       } else {
                           Err(Error::Signature)

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -386,8 +386,8 @@ pub fn inbox(
     {
         // maybe we just know an old key?
         actor.refetch(&conn).and_then(|_| User::get(&conn, actor.id))
-            .and_then(|actor| if !verify_http_headers(&actor, &headers.0, &sig).is_secure()
-                      && !act.clone().verify(&actor)
+            .and_then(|actor| if verify_http_headers(&actor, &headers.0, &sig).is_secure()
+                      || act.clone().verify(&actor)
                     {
                         Ok(())
                     } else {


### PR DESCRIPTION
Fix #398 

 - [x] try to fetch user when receiving an invalid signature
 - [x] regenerate new key-pair when sending `Delete` activity