### PR TITLE
Use multi step build to limit the docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev
 
 WORKDIR /scratch
-COPY Plume/script/wasm-deps.sh .
+COPY script/wasm-deps.sh .
 RUN chmod a+x ./wasm-deps.sh && sleep 1 && ./wasm-deps.sh
 
 WORKDIR /app
-COPY Plume/Cargo.toml Plume/Cargo.lock Plume/rust-toolchain ./
+COPY Cargo.toml Cargo.lock rust-toolchain ./
 RUN cargo install diesel_cli --no-default-features --features postgres --version '=1.3.0'
 RUN cargo install cargo-web
 
-COPY Plume/. .
+COPY . .
 
 RUN chmod a+x ./script/plume-front.sh && sleep 1 && ./script/plume-front.sh
 RUN cargo install --path ./ --force --no-default-features --features postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM rust:1-stretch
+FROM rust:1-stretch as builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     gettext \
     postgresql-client \
     libpq-dev \
@@ -10,17 +11,37 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     openssl \
     libssl-dev
+
 WORKDIR /scratch
-COPY script/wasm-deps.sh .
-RUN chmod a+x ./wasm-deps.sh && ./wasm-deps.sh
+COPY Plume/script/wasm-deps.sh .
+RUN chmod a+x ./wasm-deps.sh && sleep 1 && ./wasm-deps.sh
+
 WORKDIR /app
-COPY Cargo.toml Cargo.lock rust-toolchain ./
+COPY Plume/Cargo.toml Plume/Cargo.lock Plume/rust-toolchain ./
 RUN cargo install diesel_cli --no-default-features --features postgres --version '=1.3.0'
 RUN cargo install cargo-web
-COPY . .
-RUN chmod a+x ./script/plume-front.sh && ./script/plume-front.sh
+
+COPY Plume/. .
+
+RUN chmod a+x ./script/plume-front.sh && sleep 1 && ./script/plume-front.sh
 RUN cargo install --path ./ --force --no-default-features --features postgres
 RUN cargo install --path plume-cli --force --no-default-features --features postgres
 RUN cargo clean
+
+FROM debian:stretch-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libpq5 \
+    libssl1.1
+
+WORKDIR /app
+
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/cargo/bin/plm /bin/
+COPY --from=builder /usr/local/cargo/bin/plume /bin/
+COPY --from=builder /usr/local/cargo/bin/diesel /bin/
+
 CMD ["plume"]
+
 EXPOSE 7878

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,33 @@
+FROM rust:1-stretch
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gettext \
+    postgresql-client \
+    libpq-dev \
+    git \
+    curl \
+    gcc \
+    make \
+    openssl \
+    libssl-dev
+
+WORKDIR /scratch
+COPY script/wasm-deps.sh .
+RUN chmod a+x ./wasm-deps.sh && ./wasm-deps.sh
+
+WORKDIR /app
+COPY Cargo.toml Cargo.lock rust-toolchain ./
+RUN cargo install diesel_cli --no-default-features --features postgres --version '=1.3.0'
+RUN cargo install cargo-web
+
+COPY . .
+
+RUN chmod a+x ./script/plume-front.sh && ./script/plume-front.sh
+RUN cargo install --path ./ --force --no-default-features --features postgres
+RUN cargo install --path plume-cli --force --no-default-features --features postgres
+RUN cargo clean
+
+CMD ["plume"]
+
+EXPOSE 7878

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /scratch
 COPY script/wasm-deps.sh .
-RUN chmod a+x ./wasm-deps.sh && ./wasm-deps.sh
+RUN chmod a+x ./wasm-deps.sh && sleep 1 && ./wasm-deps.sh
 
 WORKDIR /app
 COPY Cargo.toml Cargo.lock rust-toolchain ./
@@ -23,7 +23,7 @@ RUN cargo install cargo-web
 
 COPY . .
 
-RUN chmod a+x ./script/plume-front.sh && ./script/plume-front.sh
+RUN chmod a+x ./script/plume-front.sh && sleep 1 && ./script/plume-front.sh
 RUN cargo install --path ./ --force --no-default-features --features postgres
 RUN cargo install --path plume-cli --force --no-default-features --features postgres
 RUN cargo clean


### PR DESCRIPTION
This change replace the Dockerfile with a multi step build to avoid huge image size (the new image should be around 130Mo including all layers), compared to more that 1Go with the full build chain. It's also more safe. This image does not include cargo (not needed in production), so the old Dockerfile is available and renamed Dockerfile.dev for those who use Docker for development setup.

Closes: #411 