### PR TITLE
Coherent markup for all feeds templates

### DIFF
--- a/templates/instance/federated.rs.html
+++ b/templates/instance/federated.rs.html
@@ -6,8 +6,7 @@
 @(ctx: BaseContext, articles: Vec<Post>, page: i32, n_pages: i32)
 
 @:base(ctx, "All the articles of the Fediverse", {}, {}, {
-<div class="h-feed">
-  <h1 "p-name">@i18n!(ctx.1, "All the articles of the Fediverse")</h1>
+  <h1>@i18n!(ctx.1, "All the articles of the Fediverse")</h1>
 
     @if let Some(_) = ctx.2 {
         @tabs(&[
@@ -30,5 +29,4 @@
         }
     </div>
     @paginate(ctx.1, page, n_pages)
-</div>
 })

--- a/templates/instance/local.rs.html
+++ b/templates/instance/local.rs.html
@@ -7,8 +7,7 @@
 @(ctx: BaseContext, instance: Instance, articles: Vec<Post>, page: i32, n_pages: i32)
 
 @:base(ctx, i18n!(ctx.1, "Articles from {}"; instance.name.clone()).as_str(), {}, {}, {
-<div class="h-feed">
-  <h1 class="p-name">@i18n!(ctx.1, "Articles from {}"; instance.name)</h1>
+  <h1>@i18n!(ctx.1, "Articles from {}"; instance.name)</h1>
 
     @if let Some(_) = ctx.2 {
         @tabs(&[
@@ -31,5 +30,4 @@
         }
     </div>
     @paginate(ctx.1, page, n_pages)
-</div>
 })


### PR DESCRIPTION
Small change to use the same markup for all feeds available in the home page. 