### PR TITLE
Fix Plume arm builds

### DIFF
--- a/script/plume-front.sh
+++ b/script/plume-front.sh
@@ -18,7 +18,7 @@ elif processor == 'armv7l':
 EOF
 )
 
-if [ "$ARCH" == "aarch64" -o "$ARCH" == "armv7l" ] ; then
+if [ $ARCH == "aarch64" -o $ARCH == "armv71" ] ; then
     export PATH=/opt/local/llvm/bin:${PATH}
     cd /app
     RUSTFLAGS="-C linker=lld" cargo web deploy -p plume-front

--- a/script/plume-front.sh
+++ b/script/plume-front.sh
@@ -10,7 +10,7 @@ if processor == 'aarch64':
     if '32bit' in architecture:
         print('armv71', end='')
     else:
-        print('arm64', end='')
+        print('aarch64', end='')
 elif processor == 'x86 64' or processor == 'x86_64':
     print('amd64', end='')
 elif processor == 'armv7l':

--- a/script/plume-front.sh
+++ b/script/plume-front.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
-ARCH=`arch`
+ARCH=$(python <<EOF
+from __future__ import print_function
+import platform
+processor = platform.machine()
+architecture = platform.architecture()
+if processor == 'aarch64':
+    # Mutli arch arm support is why this 32bit check is present
+    if '32bit' in architecture:
+        print('armv71', end='')
+    else:
+        print('arm64', end='')
+elif processor == 'x86 64' or processor == 'x86_64':
+    print('amd64', end='')
+elif processor == 'armv7l':
+    print('armhf', end='')
+EOF
+)
 
 if [ "$ARCH" == "aarch64" -o "$ARCH" == "armv7l" ] ; then
     export PATH=/opt/local/llvm/bin:${PATH}

--- a/script/wasm-deps.sh
+++ b/script/wasm-deps.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 
-ARCH=`arch`
+ARCH=$(python <<EOF
+from __future__ import print_function
+import platform
+processor = platform.machine()
+architecture = platform.architecture()
+if processor == 'aarch64':
+    # Mutli arch arm support is why this 32bit check is present
+    if '32bit' in architecture:
+        print('armv71', end='')
+    else:
+        print('arm64', end='')
+elif processor == 'x86 64' or processor == 'x86_64':
+    print('amd64', end='')
+elif processor == 'armv7l':
+    print('armhf', end='')
+EOF
+)
 
 if [ "$ARCH" == "aarch64" -o "$ARCH" == "armv7l" ] ; then
     apt-get install -y --no-install-recommends build-essential subversion ninja-build cmake
     mkdir -p /scratch/src
     cd /scratch/src
-    svn co http://llvm.org/svn/llvm-project/llvm/trunk llvm
+    # Pin LLVM to post 7.0.1 tag and pin to a known-good revision for Plume builds
+    svn co -r350977 http://llvm.org/svn/llvm-project/llvm/trunk/ llvm
     cd /scratch/src/llvm/tools
-    svn co http://llvm.org/svn/llvm-project/lld/trunk lld
+    # Pin lld to post 7.0.1 tag and pin to a known-good revision for Plume builds
+    svn co -r350975 http://llvm.org/svn/llvm-project/lld/trunk lld
     #svn co http://llvm.org/svn/llvm-project/cfe/trunk clang
     #svn co http://llvm.org/svn/llvm-project/clang-tools-extra/trunk extra
     mkdir -p /scratch/build/arm

--- a/script/wasm-deps.sh
+++ b/script/wasm-deps.sh
@@ -18,7 +18,9 @@ elif processor == 'armv7l':
 EOF
 )
 
-if [ "$ARCH" == "aarch64" -o "$ARCH" == "armv7l" ] ; then
+echo "Detected arch: $ARCH"
+
+if [ $ARCH == "aarch64" -o $ARCH == "armv71" ] ; then
     apt-get install -y --no-install-recommends build-essential subversion ninja-build cmake
     mkdir -p /scratch/src
     cd /scratch/src

--- a/script/wasm-deps.sh
+++ b/script/wasm-deps.sh
@@ -10,7 +10,7 @@ if processor == 'aarch64':
     if '32bit' in architecture:
         print('armv71', end='')
     else:
-        print('arm64', end='')
+        print('aarch64', end='')
 elif processor == 'x86 64' or processor == 'x86_64':
     print('amd64', end='')
 elif processor == 'armv7l':


### PR DESCRIPTION
llvm latest svn commit is broken as of 2019/01/12. This patch pins the llvm+lld versions used for arm compiles.

It also tweaks the architecture detection to be more reliable in multi-lib/multi-arch situations where the CPU is 64bit but the runtime is 32bit.