### PR TITLE
Add categories  to web manifest

### DIFF
--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -264,6 +264,7 @@ pub fn web_manifest(conn: DbConn) -> Result<Json<serde_json::Value>, ErrorPage> 
         "display": String::from("standalone"),
         "background_color": String::from("#f4f4f4"),
         "theme_color": String::from("#7765e3"),
+        "categories": [String::from("social")],
         "icons": [
             {
                 "src": "/static/icons/trwnh/feather/plumeFeather48.png",


### PR DESCRIPTION
This pull request add a `categories` key to the web manifest. The categories key was [recently added](https://www.aaron-gustafson.com/notebook/categories-land-in-the-web-app-manifest/ "Blog post detailing the addition of categories to the spec") to the Web Manifest spec and is a list of categorizations you want to apply to your site that serves as a hint to search engines and webapp catalogs.

The categories can be anything and there is no standardized list of vaues. The W3C is maintaining a list of commonly used values [here](https://github.com/w3c/manifest/wiki/Categories). I added _social_ to Plume's manifest based on that list, but I think eventually allowing a user defined list would be better. I don't know if there's anything in Plume currently that would enable that.