### PR TITLE
Update nodeinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["Plume contributors"]
 name = "plume"
 version = "0.2.0"
+repository = "https://github.com/Plume-org/Plume"
 
 [dependencies]
 activitypub = "0.1.3"

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -218,18 +218,20 @@ pub fn shared_inbox(conn: DbConn, data: SignedJson<serde_json::Value>, headers: 
 
 #[get("/nodeinfo")]
 pub fn nodeinfo(conn: DbConn) -> Result<Json<serde_json::Value>, ErrorPage> {
+    let local_inst = Instance::get_local(&*conn)?;
     Ok(Json(json!({
         "version": "2.0",
         "software": {
-            "name": "plume",
-            "version": env!("CARGO_PKG_VERSION")
+            "name": env!("CARGO_PKG_NAME"),
+            "version": env!("CARGO_PKG_VERSION"),
+            "repository": env!("CARGO_PKG_REPOSITORY")
         },
         "protocols": ["activitypub"],
         "services": {
             "inbound": [],
             "outbound": []
         },
-        "openRegistrations": true,
+        "openRegistrations": local_inst.open_registrations,
         "usage": {
             "users": {
                 "total": User::count_local(&*conn)?
@@ -237,7 +239,10 @@ pub fn nodeinfo(conn: DbConn) -> Result<Json<serde_json::Value>, ErrorPage> {
             "localPosts": Post::count_local(&*conn)?,
             "localComments": Comment::count_local(&*conn)?
         },
-        "metadata": {}
+        "metadata": {
+            "nodeName": local_inst.name,
+            "nodeDescription": local_inst.short_description
+        }
     })))
 }
 

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -221,7 +221,7 @@ pub fn nodeinfo(conn: DbConn) -> Result<Json<serde_json::Value>, ErrorPage> {
     Ok(Json(json!({
         "version": "2.0",
         "software": {
-            "name": "Plume",
+            "name": "plume",
             "version": env!("CARGO_PKG_VERSION")
         },
         "protocols": ["activitypub"],

--- a/src/routes/well_known.rs
+++ b/src/routes/well_known.rs
@@ -11,7 +11,11 @@ pub fn nodeinfo() -> Content<String> {
         "links": [
             {
                 "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0",
-                "href": ap_url(&format!("{domain}/nodeinfo", domain = BASE_URL.as_str()))
+                "href": ap_url(&format!("{domain}/nodeinfo/2.0", domain = BASE_URL.as_str()))
+            },
+            {
+                "rel": "http://nodeinfo.diaspora.software/ns/schema/2.1",
+                "href": ap_url(&format!("{domain}/nodeinfo/2.1", domain = BASE_URL.as_str()))
             }
         ]
     }).to_string())


### PR DESCRIPTION
Fix #433

I added the repo link to Cargo.toml so that `software.repository` could be configurable like @rhaamo suggested. I don't know if it's ok to include `software.repository` without bumping the schema version, but I didn't know if that would break any clients that parse nodeinfo with a hardcoded schema version.