### PR TITLE
Refactor with the help of Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,15 @@ jobs:
       name: "Build front"
       script: (cargo web -h || cargo install cargo-web) && cd plume-front && cargo clippy && cargo web check
       before_script: rustup component add clippy
+
     - stage: build
       name: "Build with postgresql"
       env:
         - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
       script: cargo clippy --no-default-features --features="${FEATURES}" --release
       before_script: rustup component add clippy
+
+    - stage: build
       name: "Build CLI with postgresql"
       env:
         - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
@@ -46,11 +49,14 @@ jobs:
         - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
       script: cargo clippy --no-default-features --features="${FEATURES}" --release
       before_script: rustup component add clippy
+
+    - stage: build
       name: "Build CLI with sqlite"
       env:
         - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
       script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release
       before_script: rustup component add clippy
+
     - stage: test and coverage
       name: "Test with potgresql backend"
       env:
@@ -61,6 +67,7 @@ jobs:
         - |
             cargo test --features "${FEATURES}" --no-default-features  --all --exclude plume-front &&
             ./script/compute_coverage.sh
+
     - stage: test and coverage
       name: "Test with Sqlite backend"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,30 @@ jobs:
   include:
     - stage: build
       name: "Build front"
-      script: (cargo web -h || cargo install cargo-web) && cd plume-front && cargo web check
+      script: (cargo web -h || cargo install cargo-web) && cd plume-front && cargo clippy && cargo web check
+      before_script: rustup component add clippy
     - stage: build
       name: "Build with postgresql"
       env:
         - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
-      script: cargo build --no-default-features --features="${FEATURES}" --release
+      script: cargo clippy --no-default-features --features="${FEATURES}" --release
+      before_script: rustup component add clippy
+      name: "Build CLI with postgresql"
+      env:
+        - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
+      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release
+      before_script: rustup component add clippy
     - stage: build
       name: "Build with sqlite"
       env:
         - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
-      script: cargo build --no-default-features --features="${FEATURES}" --release
+      script: cargo clippy --no-default-features --features="${FEATURES}" --release
+      before_script: rustup component add clippy
+      name: "Build CLI with sqlite"
+      env:
+        - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
+      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release
+      before_script: rustup component add clippy
     - stage: test and coverage
       name: "Test with potgresql backend"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,34 +27,34 @@ jobs:
   include:
     - stage: build
       name: "Build front"
-      script: (cargo web -h || cargo install cargo-web) && cd plume-front && cargo clippy && cargo web check
+      script: (cargo web -h || cargo install cargo-web) && cd plume-front && cargo clippy -- -D warnings && cargo web check
       before_script: rustup component add clippy
 
     - stage: build
       name: "Build with postgresql"
       env:
         - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
-      script: cargo clippy --no-default-features --features="${FEATURES}" --release
+      script: cargo clippy --no-default-features --features="${FEATURES}" --release -- -D warnings
       before_script: rustup component add clippy
 
     - stage: build
       name: "Build CLI with postgresql"
       env:
         - MIGRATION_DIR=migrations/postgres FEATURES=postgres DATABASE_URL=postgres://postgres@localhost/plume
-      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release
+      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release -- -D warnings
       before_script: rustup component add clippy
     - stage: build
       name: "Build with sqlite"
       env:
         - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
-      script: cargo clippy --no-default-features --features="${FEATURES}" --release
+      script: cargo clippy --no-default-features --features="${FEATURES}" --release -- -D warnings
       before_script: rustup component add clippy
 
     - stage: build
       name: "Build CLI with sqlite"
       env:
         - MIGRATION_DIR=migrations/sqlite   FEATURES=sqlite   DATABASE_URL=plume.sqlite3
-      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release
+      script: cd plume-cli && cargo clippy --no-default-features --features="${FEATURES}" --release -- -D warnings
       before_script: rustup component add clippy
 
     - stage: test and coverage

--- a/plume-cli/src/search.rs
+++ b/plume-cli/src/search.rs
@@ -60,13 +60,7 @@ fn init<'a>(args: &ArgMatches<'a>, conn: &Connection) {
     let path = Path::new(path).join("search_index");
 
     let can_do = match read_dir(path.clone()) { // try to read the directory specified
-        Ok(mut contents) => {
-            if contents.next().is_none()  {
-                true
-            } else {
-                false
-            }
-        },
+        Ok(mut contents) =>  contents.next().is_none(),
         Err(e) => if e.kind() == ErrorKind::NotFound {
             true
         } else {
@@ -107,5 +101,3 @@ fn unlock<'a>(args: &ArgMatches<'a>) {
 
     remove_file(path).unwrap();
 }
-
-

--- a/plume-front/src/editor.rs
+++ b/plume-front/src/editor.rs
@@ -72,7 +72,7 @@ fn init_widget(
     }
     widget.append_child(&document().create_text_node(&content));
     if disable_return {
-        widget.add_event_listener(no_return);        
+        widget.add_event_listener(no_return);
     }
 
     parent.append_child(&widget);
@@ -128,7 +128,7 @@ pub fn init() -> Result<(), EditorError> {
 
             popup.class_list().add("show").unwrap();
             bg.class_list().add("show").unwrap();
-        }));        
+        }));
     }
     Ok(())
 }
@@ -233,7 +233,7 @@ fn make_editable(tag: &'static str) -> Element {
     elt
 }
 
-fn placeholder<'a>(elt: HtmlElement, text: &'a str) -> HtmlElement {
+fn placeholder(elt: HtmlElement, text: &str) -> HtmlElement {
     elt.dataset().insert("placeholder", text).unwrap();
     elt.dataset().insert("edited", "false").unwrap();
 
@@ -248,7 +248,7 @@ fn placeholder<'a>(elt: HtmlElement, text: &'a str) -> HtmlElement {
 
             let ph = document().create_element("span").expect("Couldn't create placeholder");
             ph.class_list().add("placeholder").expect("Couldn't add class");
-            ph.append_child(&document().create_text_node(&elt.dataset().get("placeholder").unwrap_or(String::new())));
+            ph.append_child(&document().create_text_node(&elt.dataset().get("placeholder").unwrap_or_default()));
             elt.append_child(&ph);
         }
     }));

--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -54,21 +54,20 @@ fn menu() {
 
 /// Clear the URL of the search page before submitting request
 fn search() {
-    document().get_element_by_id("form")
-        .map(|form| {
-            form.add_event_listener(|_: SubmitEvent| {
-                document().query_selector_all("#form input").map(|inputs| {
-                    for input in inputs {
-                        js! {
-                            if (@{&input}.name === "") {
-                                @{&input}.name = @{&input}.id
-                            }
-                            if (@{&input}.name && !@{&input}.value) {
-                                @{&input}.name = "";
-                            }
+    if let Some(form) = document().get_element_by_id("form") {
+        form.add_event_listener(|_: SubmitEvent| {
+            document().query_selector_all("#form input").map(|inputs| {
+                for input in inputs {
+                    js! {
+                        if (@{&input}.name === "") {
+                            @{&input}.name = @{&input}.id
+                        }
+                        if (@{&input}.name && !@{&input}.value) {
+                            @{&input}.name = "";
                         }
                     }
-                }).ok();
-            });
+                }
+            }).ok();
         });
+    }
 }

--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -38,18 +38,16 @@ fn main() {
 /// It should normally be working fine even without this code
 /// But :focus-within is not yet supported by Webkit/Blink
 fn menu() {
-    document().get_element_by_id("menu")
-        .map(|button| {
-            document().get_element_by_id("content")
-                .map(|menu| {
-                    button.add_event_listener(|_: ClickEvent| {
-                        document().get_element_by_id("menu").map(|menu| menu.class_list().add("show"));
-                    });
-                    menu.add_event_listener(|_: ClickEvent| {
-                        document().get_element_by_id("menu").map(|menu| menu.class_list().remove("show"));
-                    });
-                })
-        });
+    if let Some(button) = document().get_element_by_id("menu") {
+        if let Some(menu) = document().get_element_by_id("content") {
+            button.add_event_listener(|_: ClickEvent| {
+                document().get_element_by_id("menu").map(|menu| menu.class_list().add("show"));
+            });
+            menu.add_event_listener(|_: ClickEvent| {
+                document().get_element_by_id("menu").map(|menu| menu.class_list().remove("show"));
+            });
+        }
+    }
 }
 
 /// Clear the URL of the search page before submitting request

--- a/plume-models/src/api_tokens.rs
+++ b/plume-models/src/api_tokens.rs
@@ -90,9 +90,9 @@ impl<'a, 'r> FromRequest<'a, 'r> for ApiToken {
 
         let mut parsed_header = headers[0].split(' ');
         let auth_type = parsed_header.next()
-            .map_or_else(|| Outcome::Failure((Status::BadRequest, TokenError::NoType)), |t| Outcome::Success(t))?;
+            .map_or_else(|| Outcome::Failure((Status::BadRequest, TokenError::NoType)), Outcome::Success)?;
         let val = parsed_header.next()
-            .map_or_else(|| Outcome::Failure((Status::BadRequest, TokenError::NoValue)), |t| Outcome::Success(t))?;
+            .map_or_else(|| Outcome::Failure((Status::BadRequest, TokenError::NoValue)), Outcome::Success)?;
 
         if auth_type == "Bearer" {
             let conn = request.guard::<DbConn>().map_failure(|_| (Status::InternalServerError, TokenError::DbError))?;

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(try_trait)]
+#![feature(never_type)]
 
 extern crate activitypub;
 extern crate ammonia;

--- a/plume-models/src/medias.rs
+++ b/plume-models/src/medias.rs
@@ -70,8 +70,8 @@ impl Media {
     pub fn page_for_user(conn: &Connection, user: &User, (min, max): (i32, i32)) -> Result<Vec<Media>> {
         medias::table
             .filter(medias::owner_id.eq(user.id))
-            .offset(min as i64)
-            .limit((max - min) as i64)
+            .offset(i64::from(min))
+            .limit(i64::from(max - min))
             .load::<Media>(conn)
             .map_err(Error::from)
     }

--- a/plume-models/src/safe_string.rs
+++ b/plume-models/src/safe_string.rs
@@ -24,7 +24,7 @@ lazy_static! {
             .url_relative(UrlRelative::Custom(Box::new(url_add_prefix)))
             .add_tag_attributes(
                 "iframe",
-                [ "width", "height", "src", "frameborder" ].iter().map(|&v| v),
+                [ "width", "height", "src", "frameborder" ].iter().cloned(),
             )
             .add_tag_attributes(
                 "video",

--- a/plume-models/src/search/mod.rs
+++ b/plume-models/src/search/mod.rs
@@ -9,6 +9,7 @@ pub use self::query::PlumeQuery as Query;
 pub(crate) mod tests {
     use super::{Query, Searcher};
     use std::env::temp_dir;
+    use std::str::FromStr;
     use diesel::Connection;
 
     use plume_common::activity_pub::inbox::Deletable;
@@ -65,7 +66,7 @@ pub(crate) mod tests {
             ("after:2017-11-05 after:2018-01-01", "after:2018-01-01"),
         ];
         for (source, res) in vector {
-            assert_eq!(&Query::from_str(source).to_string(), res);
+            assert_eq!(&Query::from_str(source).unwrap().to_string(), res);
             assert_eq!(Query::new().parse_query(source).to_string(), res);
         }
     }
@@ -141,18 +142,18 @@ pub(crate) mod tests {
             }).unwrap();
 
             searcher.commit();
-            assert_eq!(searcher.search_document(conn, Query::from_str(&title), (0,1))[0].id, post.id);
+            assert_eq!(searcher.search_document(conn, Query::from_str(&title).unwrap(), (0,1))[0].id, post.id);
 
             let newtitle = random_hex()[..8].to_owned();
             post.title = newtitle.clone();
             post.update(conn, &searcher).unwrap();
             searcher.commit();
-            assert_eq!(searcher.search_document(conn, Query::from_str(&newtitle), (0,1))[0].id, post.id);
-            assert!(searcher.search_document(conn, Query::from_str(&title), (0,1)).is_empty());
+            assert_eq!(searcher.search_document(conn, Query::from_str(&newtitle).unwrap(), (0,1))[0].id, post.id);
+            assert!(searcher.search_document(conn, Query::from_str(&title).unwrap(), (0,1)).is_empty());
 
             post.delete(&(conn, &searcher)).unwrap();
             searcher.commit();
-            assert!(searcher.search_document(conn, Query::from_str(&newtitle), (0,1)).is_empty());
+            assert!(searcher.search_document(conn, Query::from_str(&newtitle).unwrap(), (0,1)).is_empty());
 
             Ok(())
         });

--- a/plume-models/src/search/query.rs
+++ b/plume-models/src/search/query.rs
@@ -208,7 +208,7 @@ impl PlumeQuery {
     }
 
     // split a string into a token and a rest
-    pub fn get_first_token<'a>(mut query: &'a str) -> (&'a str, &'a str) {
+    pub fn get_first_token(mut query: &str) -> (&str, &str) {
         query = query.trim();
         if query.is_empty() {
             ("", "")
@@ -244,22 +244,22 @@ impl PlumeQuery {
     fn from_str_req(&mut self, mut query: &str) -> &mut Self {
         query = query.trim_left();
         if query.is_empty() {
-            self
-        } else {
-            let occur = if query.get(0..1).map(|v| v=="+").unwrap_or(false) {
-                query = &query[1..];
-                Occur::Must
-            } else if query.get(0..1).map(|v| v=="-").unwrap_or(false) {
-                query = &query[1..];
-                Occur::MustNot
-            } else {
-                Occur::Should
-            };
-            gen_parser!(self, query, occur; normal: title, subtitle, content, tag,
-                            instance, author, blog, lang, license;
-                            date: after, before);
-            self.from_str_req(query)
+            return self
         }
+
+        let occur = if query.get(0..1).map(|v| v=="+").unwrap_or(false) {
+            query = &query[1..];
+            Occur::Must
+        } else if query.get(0..1).map(|v| v=="-").unwrap_or(false) {
+            query = &query[1..];
+            Occur::MustNot
+        } else {
+            Occur::Should
+        };
+        gen_parser!(self, query, occur; normal: title, subtitle, content, tag,
+                        instance, author, blog, lang, license;
+                        date: after, before);
+        self.from_str_req(query)
     }
 
     // map a token and it's field to a query

--- a/plume-models/src/search/query.rs
+++ b/plume-models/src/search/query.rs
@@ -226,26 +226,22 @@ impl PlumeQuery {
         query = query.trim();
         if query.is_empty() {
             ("", "")
-        } else {
-            if query.get(0..1).map(|v| v=="\"").unwrap_or(false) {
-                    if let Some(index) = query[1..].find('"') {
-                        query.split_at(index+2)
-                    } else {
-                        (query, "")
-                    }
-            } else if query.get(0..2).map(|v| v=="+\"" || v=="-\"").unwrap_or(false) {
-                    if let Some(index) = query[2..].find('"') {
-                        query.split_at(index+3)
-                    } else {
-                        (query, "")
-                    }
-            } else {
-                if let Some(index) = query.find(' ') {
-                    query.split_at(index)
+        } else if query.get(0..1).map(|v| v=="\"").unwrap_or(false) {
+                if let Some(index) = query[1..].find('"') {
+                    query.split_at(index+2)
                 } else {
                     (query, "")
                 }
-            }
+        } else if query.get(0..2).map(|v| v=="+\"" || v=="-\"").unwrap_or(false) {
+                if let Some(index) = query[2..].find('"') {
+                    query.split_at(index+3)
+                } else {
+                    (query, "")
+                }
+        } else if let Some(index) = query.find(' ') {
+            query.split_at(index)
+        } else {
+            (query, "")
         }
     }
 
@@ -290,7 +286,7 @@ impl PlumeQuery {
             let user_term = Term::from_field_text(field, &token[..pos]);
             let instance_term = Term::from_field_text(Searcher::schema().get_field("instance").unwrap(), &token[pos+1..]);
             Box::new(BooleanQuery::from(vec![
-                        (Occur::Must, Box::new(TermQuery::new(user_term, if field_name=="author" { IndexRecordOption::Basic } 
+                        (Occur::Must, Box::new(TermQuery::new(user_term, if field_name=="author" { IndexRecordOption::Basic }
                                                                          else { IndexRecordOption::WithFreqsAndPositions }
                                                                     )) as Box<dyn Query + 'static>),
                         (Occur::Must, Box::new(TermQuery::new(instance_term, IndexRecordOption::Basic))),
@@ -340,4 +336,3 @@ impl ToString for PlumeQuery {
         result
     }
 }
-

--- a/plume-models/src/search/query.rs
+++ b/plume-models/src/search/query.rs
@@ -87,9 +87,9 @@ macro_rules! gen_to_string {
         $(
         for (occur, val) in &$self.$field {
             if val.contains(' ') {
-                $result.push_str(&format!("{}{}:\"{}\" ", Self::occur_to_str(&occur), stringify!($field), val));
+                $result.push_str(&format!("{}{}:\"{}\" ", Self::occur_to_str(*occur), stringify!($field), val));
             } else {
-                $result.push_str(&format!("{}{}:{} ", Self::occur_to_str(&occur), stringify!($field), val));
+                $result.push_str(&format!("{}{}:{} ", Self::occur_to_str(*occur), stringify!($field), val));
             }
         }
         )*
@@ -232,7 +232,7 @@ impl PlumeQuery {
     }
 
     // map each Occur state to a prefix
-    fn occur_to_str(occur: &Occur) -> &'static str {
+    fn occur_to_str(occur: Occur) -> &'static str {
         match occur {
             Occur::Should => "",
             Occur::Must => "+",
@@ -327,9 +327,9 @@ impl ToString for PlumeQuery {
         let mut result = String::new();
         for (occur, val) in &self.text {
             if val.contains(' ') {
-                result.push_str(&format!("{}\"{}\" ", Self::occur_to_str(&occur), val));
+                result.push_str(&format!("{}\"{}\" ", Self::occur_to_str(*occur), val));
             } else {
-                result.push_str(&format!("{}{} ", Self::occur_to_str(&occur), val));
+                result.push_str(&format!("{}{} ", Self::occur_to_str(*occur), val));
             }
         }
 

--- a/plume-models/src/search/query.rs
+++ b/plume-models/src/search/query.rs
@@ -241,6 +241,9 @@ impl PlumeQuery {
     }
 
     // recursive parser for query string
+    // allow this clippy lint for now, until someone figures out how to
+    // refactor this better.
+    #[allow(clippy::wrong_self_convention)]
     fn from_str_req(&mut self, mut query: &str) -> &mut Self {
         query = query.trim_left();
         if query.is_empty() {

--- a/plume-models/src/search/query.rs
+++ b/plume-models/src/search/query.rs
@@ -148,20 +148,6 @@ impl PlumeQuery {
         Default::default()
     }
 
-    /// Create a new Query from &str
-    /// Same as doing
-    /// ```rust
-    /// # extern crate plume_models;
-    /// # use plume_models::search::Query;
-    /// let mut q = Query::new();
-    /// q.parse_query("some query");
-    /// ```
-    pub fn from_str(query: &str) -> Self {
-        let mut res: Self = Default::default();
-
-        res.from_str_req(&query.trim());
-        res
-    }
 
     /// Parse a query string into this Query
     pub fn parse_query(&mut self, query: &str) -> &mut Self {
@@ -316,6 +302,25 @@ impl PlumeQuery {
     }
 }
 
+impl std::str::FromStr for PlumeQuery {
+
+    type Err = !;
+
+    /// Create a new Query from &str
+    /// Same as doing
+    /// ```rust
+    /// # extern crate plume_models;
+    /// # use plume_models::search::Query;
+    /// let mut q = Query::new();
+    /// q.parse_query("some query");
+    /// ```
+    fn from_str(query: &str) -> Result<PlumeQuery, !> {
+        let mut res: PlumeQuery = Default::default();
+
+        res.from_str_req(&query.trim());
+        Ok(res)
+    }
+}
 
 impl ToString for PlumeQuery {
     fn to_string(&self) -> String {

--- a/plume-models/src/search/searcher.rs
+++ b/plume-models/src/search/searcher.rs
@@ -183,7 +183,7 @@ impl Searcher {
         let res = searcher.search(&query.into_query(), &collector).unwrap();
 
         res.get(min as usize..).unwrap_or(&[])
-            .into_iter()
+            .iter()
             .filter_map(|(_,doc_add)| {
                 let doc = searcher.doc(*doc_add).ok()?;
                 let id = doc.get_first(post_id)?;

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -171,7 +171,8 @@ impl User {
             .select(post_authors::post_id)
             .load(conn)?;
         for post_id in all_their_posts_ids {
-            // this makes no sense (to me)
+            // disabling this lint, because otherwise we'd have to turn it on
+            // the head, and make it even harder to follow!
             #[allow(clippy::op_ref)]
             let has_other_authors = post_authors::table
                 .filter(post_authors::post_id.eq(post_id))

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -489,7 +489,7 @@ impl User {
         Ok(json["items"]
             .as_array()
             .unwrap_or(&vec![])
-            .into_iter()
+            .iter()
             .filter_map(|j| serde_json::from_value(j.clone()).ok())
             .collect::<Vec<T>>())
     }
@@ -512,7 +512,7 @@ impl User {
         Ok(json["items"]
             .as_array()
             .unwrap_or(&vec![])
-            .into_iter()
+            .iter()
             .filter_map(|j| serde_json::from_value(j.clone()).ok())
             .collect::<Vec<String>>())
     }
@@ -746,7 +746,7 @@ impl User {
     pub fn avatar_url(&self, conn: &Connection) -> String {
         self.avatar_id.and_then(|id|
             Media::get(conn, id).and_then(|m| m.url(conn)).ok()
-        ).unwrap_or("/static/default-avatar.png".to_string())
+        ).unwrap_or_else(|| "/static/default-avatar.png".to_string())
     }
 
     pub fn webfinger(&self, conn: &Connection) -> Result<Webfinger> {

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -171,6 +171,8 @@ impl User {
             .select(post_authors::post_id)
             .load(conn)?;
         for post_id in all_their_posts_ids {
+            // this makes no sense (to me)
+            #[allow(clippy::op_ref)]
             let has_other_authors = post_authors::table
                 .filter(post_authors::post_id.eq(post_id))
                 .filter(post_authors::author_id.ne(self.id))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::too_many_arguments)]
 use rocket::{response::{self, Responder}, request::{Form, Request}};
 use rocket_contrib::json::Json;
 use serde_json;

--- a/src/inbox.rs
+++ b/src/inbox.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::too_many_arguments)]
 use activitypub::{
     activity::{
         Announce,

--- a/src/mail.rs
+++ b/src/mail.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::too_many_arguments)]
 use lettre_email::Email;
 use std::env;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,8 @@ fn init_pool() -> Option<DbPool> {
 fn main() {
     let dbpool = init_pool().expect("main: database pool initialization error");
     let workpool = ScheduledThreadPool::with_name("worker {}", num_cpus::get());
+    // we want a fast exit here, so
+    #[allow(clippy::match_wild_err_arm)]
     let searcher = match UnmanagedSearcher::open(&"search_index") {
         Err(Error::Search(e)) => match e {
             SearcherError::WriteLockAcquisitionError => panic!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::too_many_arguments)]
 #![feature(decl_macro, proc_macro_hygiene)]
 
 extern crate activitypub;

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -135,7 +135,7 @@ pub fn delete(name: String, rockets: PlumeRocket) -> Result<Redirect, Ructe>{
     let blog = Blog::find_by_fqn(&*conn, &name).expect("blog::delete: blog not found");
     let user = rockets.user;
     let intl = rockets.intl;
-    let searcher = rockets.searcher.unwrap();
+    let searcher = rockets.searcher;
 
     if user.clone().and_then(|u| u.is_author_in(&*conn, &blog).ok()).unwrap_or(false) {
         blog.delete(&conn, &searcher).expect("blog::expect: deletion error");

--- a/src/routes/medias.rs
+++ b/src/routes/medias.rs
@@ -35,7 +35,7 @@ pub fn upload(user: User, data: Data, ct: &ContentType, conn: DbConn) -> Result<
             SaveResult::Full(entries) => {
                 let fields = entries.fields;
 
-                let filename = fields.get("file").and_then(|v| v.into_iter().next())
+                let filename = fields.get("file").and_then(|v| v.iter().next())
                     .ok_or_else(|| status::BadRequest(Some("No file uploaded")))?.headers
                     .filename.clone();
                 // Remove extension if it contains something else than just letters and numbers

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -25,9 +25,9 @@ use Searcher;
 pub struct PlumeRocket<'a> {
     conn: DbConn,
     intl: I18n,
-    searcher: Option<Searcher<'a>>,
     user: Option<User>,
-    worker: Option<Worker<'a>>,
+    searcher: Searcher<'a>,
+    worker: Worker<'a>,
 }
 
 impl<'a, 'r> FromRequest<'a, 'r> for PlumeRocket<'a> {
@@ -37,8 +37,8 @@ impl<'a, 'r> FromRequest<'a, 'r> for PlumeRocket<'a> {
         let conn = request.guard::<DbConn>()?;
         let intl = request.guard::<I18n>()?;
         let user = Some(request.guard::<User>()?);
-        let worker = Some(request.guard::<Worker>()?);
-        let searcher = Some(request.guard::<Searcher>()?);
+        let worker = request.guard::<Worker>()?;
+        let searcher = request.guard::<Searcher>()?;
         rocket::Outcome::Success(PlumeRocket {
             conn,
             intl,

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -36,7 +36,7 @@ impl<'a, 'r> FromRequest<'a, 'r> for PlumeRocket<'a> {
     fn from_request(request: &'a Request<'r>) -> request::Outcome<PlumeRocket<'a>, ()> {
         let conn = request.guard::<DbConn>()?;
         let intl = request.guard::<I18n>()?;
-        let user = Some(request.guard::<User>()?);
+        let user = request.guard::<User>().succeeded();
         let worker = request.guard::<Worker>()?;
         let searcher = request.guard::<Searcher>()?;
         rocket::Outcome::Success(PlumeRocket {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -45,7 +45,7 @@ impl Page {
         }
     }
 
-    pub fn limits(&self) -> (i32, i32) {
+    pub fn limits(self) -> (i32, i32) {
         ((self.0 - 1) * ITEMS_PER_PAGE, self.0 * ITEMS_PER_PAGE)
     }
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::too_many_arguments)]
 use atom_syndication::{ContentBuilder, Entry, EntryBuilder, LinkBuilder, Person, PersonBuilder};
 use rocket::{
     http::{

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -263,7 +263,7 @@ pub fn update(blog: String, slug: String, user: User, cl: ContentLen, form: Leni
             b,
             true,
             &*form,
-            form.draft.clone(),
+            form.draft,
             Some(post),
             errors.clone(),
             medias.clone(),

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -227,8 +227,8 @@ pub fn update(blog: String, slug: String, cl: ContentLen, form: LenientForm<NewP
                 false
             };
 
-            let searcher = rockets.searcher.unwrap();
-            let worker = rockets.worker.unwrap();
+            let searcher = rockets.searcher;
+            let worker = rockets.worker;
             post.slug = new_slug.clone();
             post.title = form.title.clone();
             post.subtitle = form.subtitle.clone();
@@ -335,7 +335,7 @@ pub fn create(blog_name: String, form: LenientForm<NewPostForm>, cl: ContentLen,
             &Instance::get_local(&conn).expect("post::create: local instance error").public_domain
         );
 
-        let searcher = rockets.searcher.unwrap();
+        let searcher = rockets.searcher;
         let post = Post::insert(&*conn, NewPost {
             blog_id: blog.id,
             slug: slug.to_string(),
@@ -389,7 +389,7 @@ pub fn create(blog_name: String, form: LenientForm<NewPostForm>, cl: ContentLen,
 
             let act = post.create_activity(&*conn).expect("posts::create: activity error");
             let dest = User::one_by_instance(&*conn).expect("posts::create: dest error");
-            let worker = rockets.worker.unwrap();
+            let worker = rockets.worker;
             worker.execute(move || broadcast(&user, act, dest));
         }
 
@@ -424,8 +424,8 @@ pub fn delete(blog_name: String, slug: String, rockets: PlumeRocket) -> Result<R
             return Ok(Redirect::to(uri!(details: blog = blog_name.clone(), slug = slug.clone(), responding_to = _)))
         }
 
-        let searcher = rockets.searcher.unwrap();
-        let worker = rockets.worker.unwrap();
+        let searcher = rockets.searcher;
+        let worker = rockets.worker;
 
         let dest = User::one_by_instance(&*conn)?;
         let delete_activity = post.delete(&(&conn, &searcher))?;

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -8,6 +8,7 @@ use plume_models::{
 use routes::Page;
 use template_utils::Ructe;
 use Searcher;
+use std::str::FromStr;
 
 #[derive(Default, FromForm)]
 pub struct SearchQuery {
@@ -57,7 +58,7 @@ macro_rules! param_to_query {
 pub fn search(query: Option<Form<SearchQuery>>, conn: DbConn, searcher: Searcher, user: Option<User>, intl: I18n) -> Ructe {
     let query = query.map(|f| f.into_inner()).unwrap_or_default();
     let page = query.page.unwrap_or_default();
-    let mut parsed_query = Query::from_str(&query.q.as_ref().map(|q| q.as_str()).unwrap_or_default());
+    let mut parsed_query = Query::from_str(&query.q.as_ref().map(|q| q.as_str()).unwrap_or_default()).unwrap_or_default();
 
     param_to_query!(query, parsed_query; normal: title, subtitle, content, tag,
               instance, author, blog, lang, license;

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -48,8 +48,8 @@ pub fn details(
     let user = User::find_by_fqn(&*conn, &name)?;
     let recents = Post::get_recents_for_author(&*conn, &user, 6)?;
     let reshares = Reshare::get_recents_for_author(&*conn, &user, 6)?;
-    let searcher = rockets.searcher.unwrap();
-    let worker = rockets.worker.unwrap();
+    let searcher = rockets.searcher;
+    let worker = rockets.worker;
 
     if !user.get_instance(&*conn)?.local {
         // Fetch new articles

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -23,7 +23,7 @@ use plume_models::{
     blogs::Blog, db_conn::DbConn, follows, headers::Headers, instance::Instance, posts::{LicensedArticle, Post},
     reshares::Reshare, users::*,
 };
-use routes::{Page, errors::ErrorPage};
+use routes::{Page, PlumeRocket, errors::ErrorPage};
 use template_utils::Ructe;
 use Worker;
 use Searcher;
@@ -39,18 +39,17 @@ pub fn me(user: Option<User>) -> Result<Redirect, Flash<Redirect>> {
 #[get("/@/<name>", rank = 2)]
 pub fn details(
     name: String,
-    conn: DbConn,
-    account: Option<User>,
-    worker: Worker,
+    rockets: PlumeRocket,
     fetch_articles_conn: DbConn,
     fetch_followers_conn: DbConn,
     update_conn: DbConn,
-    intl: I18n,
-    searcher: Searcher,
 ) -> Result<Ructe, ErrorPage> {
+    let conn = rockets.conn;
     let user = User::find_by_fqn(&*conn, &name)?;
     let recents = Post::get_recents_for_author(&*conn, &user, 6)?;
     let reshares = Reshare::get_recents_for_author(&*conn, &user, 6)?;
+    let searcher = rockets.searcher.unwrap();
+    let worker = rockets.worker.unwrap();
 
     if !user.get_instance(&*conn)?.local {
         // Fetch new articles
@@ -99,6 +98,8 @@ pub fn details(
         }
     }
 
+    let account = rockets.user;
+    let intl = rockets.intl;
     Ok(render!(users::details(
         &(&*conn, &intl.catalog, account.clone()),
         user.clone(),

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -27,7 +27,7 @@ impl<'r> Responder<'r> for Ructe {
         let mut hasher = DefaultHasher::new();
         hasher.write(&self.0);
         let etag = format!("{:x}", hasher.finish());
-        if r.headers().get("If-None-Match").any(|s| &s[1..s.len()-1] == etag) {
+        if r.headers().get("If-None-Match").any(|s| s[1..s.len()-1] == etag) {
             Response::build()
                 .status(Status::NotModified)
                 .header(ETag(EntityTag::strong(etag)))

--- a/templates/blogs/details.rs.html
+++ b/templates/blogs/details.rs.html
@@ -5,7 +5,7 @@
 @use template_utils::*;
 @use routes::*;
 
-@(ctx: BaseContext, blog: Blog, authors: &Vec<User>, total_articles: i64, page: i32, n_pages: i32, is_author: bool, posts: Vec<Post>)
+@(ctx: BaseContext, blog: Blog, authors: &[User], total_articles: i64, page: i32, n_pages: i32, is_author: bool, posts: Vec<Post>)
 
 @:base(ctx, blog.title.clone(), {}, {
     <a href="@uri!(blogs::details: name = &blog.fqn, page = _)">@blog.title</a>
@@ -36,7 +36,7 @@
             @i18n!(ctx.1, "Latest articles")
             <small><a href="@uri!(blogs::atom_feed: name = &blog.fqn)" title="Atom feed">@icon!("rss")</a></small>
         </h2>
-        @if posts.len() < 1 {
+        @if posts.is_empty() {
             <p>@i18n!(ctx.1, "No posts to see here yet.")</p>
         }
         @if is_author {

--- a/templates/instance/federated.rs.html
+++ b/templates/instance/federated.rs.html
@@ -9,7 +9,7 @@
 <div class="h-feed">
   <h1 "p-name">@i18n!(ctx.1, "All the articles of the Fediverse")</h1>
 
-    @if let Some(_) = ctx.2 {
+    @if ctx.2.is_some() {
         @tabs(&[
             (&uri!(instance::index).to_string(), i18n!(ctx.1, "Latest articles"), false),
             (&uri!(instance::feed: _).to_string(), i18n!(ctx.1, "Your feed"), false),

--- a/templates/instance/local.rs.html
+++ b/templates/instance/local.rs.html
@@ -10,7 +10,7 @@
 <div class="h-feed">
   <h1 class="p-name">@i18n!(ctx.1, "Articles from {}"; instance.name)</h1>
 
-    @if let Some(_) = ctx.2 {
+    @if ctx.2.is_some() {
         @tabs(&[
             (&uri!(instance::index).to_string(), i18n!(ctx.1, "Latest articles"), false),
             (&uri!(instance::feed: _).to_string(), i18n!(ctx.1, "Your feed"), false),

--- a/templates/medias/details.rs.html
+++ b/templates/medias/details.rs.html
@@ -14,7 +14,7 @@
 
     <section>
         <figure class="media">
-            @Html(media.html(ctx.0).unwrap_or(SafeString::new("")))
+            @Html(media.html(ctx.0).unwrap_or_else(|_| SafeString::new("")))
             <figcaption>@media.alt_text</figcaption>
         </figure>
         <div>
@@ -22,7 +22,7 @@
                 @i18n!(ctx.1, "Markdown syntax")
                 <small>@i18n!(ctx.1, "Copy it into your articles, to insert this media:")</small>
             </p>
-            <code>@media.markdown(ctx.0).unwrap_or(SafeString::new(""))</code>
+            <code>@media.markdown(ctx.0).unwrap_or_else(|_| SafeString::new(""))</code>
         </div>
         <div>
 	    @if media.category() == MediaCategory::Image {

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -5,7 +5,7 @@
 @(ctx: BaseContext, comment_tree: &CommentTree, in_reply_to: Option<&str>, blog: &str, slug: &str)
 
 @if let Some(ref comm) = Some(&comment_tree.comment) {
-@if let Some(author) = comm.get_author(ctx.0).ok() {
+@if let Ok(author) = comm.get_author(ctx.0) {
 <div class="comment u-comment h-cite" id="comment-@comm.id">
     <a class="author u-author h-card" href="@uri!(user::details: name = &author.fqn)">
         @avatar(ctx.0, &author, Size::Small, true, ctx.1)

--- a/templates/partials/comment.rs.html
+++ b/templates/partials/comment.rs.html
@@ -10,7 +10,7 @@
     <a class="author u-author h-card" href="@uri!(user::details: name = &author.fqn)">
         @avatar(ctx.0, &author, Size::Small, true, ctx.1)
         <span class="display-name p-name">@author.name()</span>
-        <small>@&author.fqn</small>
+        <small>@author.fqn</small>
 	    </a>
     @if let Some(ref ap_url) = comm.ap_url {
         <a class="u-url" href="@ap_url"></a>

--- a/templates/partials/home_feed.rs.html
+++ b/templates/partials/home_feed.rs.html
@@ -4,7 +4,7 @@
 
 @(ctx: BaseContext, articles: Vec<Post>, link: &str, title: String)
 
-@if articles.len() > 0 {
+@if !articles.is_empty() {
 <div class="h-feed">
     <h2><span class="p-name">@title</span> &mdash; <a href="@link">@i18n!(ctx.1, "View all")</a></h2>
     <div class="cards spaced">

--- a/templates/posts/details.rs.html
+++ b/templates/posts/details.rs.html
@@ -23,8 +23,8 @@
     <a href="@uri!(blogs::details: name = &blog.fqn, page = _)">@blog.title</a>
 }, {
 <div class="h-entry">
-    <h1 class="article p-name">@&article.title</h1>
-    <h2 class="article p-summary">@&article.subtitle</h2>
+    <h1 class="article p-name">@article.title</h1>
+    <h2 class="article p-summary">@article.subtitle</h2>
     <div class="article-info">
         <span class="author">
             @Html(i18n!(ctx.1, "Written by {0}"; format!("<a href=\"{}\">{}</a>",

--- a/templates/posts/new.rs.html
+++ b/templates/posts/new.rs.html
@@ -27,7 +27,7 @@
         @input!(ctx.1, subtitle (optional text), "Subtitle", form, errors.clone(), "")
 
         @if let Some(ValidationErrorsKind::Field(errs)) = errors.clone().errors().get("content") {
-            @format!(r#"<p class="error">{}</p>"#, errs[0].message.clone().unwrap_or(Cow::from("Unknown error")))
+            @format!(r#"<p class="error">{}</p>"#, errs[0].message.clone().unwrap_or_else(|| Cow::from("Unknown error")))
         }
 
         <label for="editor-content">@i18n!(ctx.1, "Content")<small>@i18n!(ctx.1, "Markdown syntax is supported")</small></label>

--- a/templates/users/header.rs.html
+++ b/templates/users/header.rs.html
@@ -11,7 +11,7 @@
 
             <h1 class="grow flex vertical">
                 <span class="p-name">@user.name()</span>
-                <small class="p-nickname">@&user.fqn</small>
+                <small class="p-nickname">@user.fqn</small>
             </h1>
 
             <p>


### PR DESCRIPTION
We add clippy as our build — also rectifying the missing `plume-cli` build!

In the next step we follow clippy's advise and fix some of the "simple" mistakes in our code, such as style or map usage.

Finally, we refactor some hard bits that need extraction of new types, or refactoring of function call-types, especially those that thread thru macros, and, of course functions with ~15 parameters should probably be rethought.