### PR TITLE
Fix wrong condition, resulting in 404 for valid NodeInfo endpoints

### DIFF
--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -218,7 +218,8 @@ pub fn shared_inbox(conn: DbConn, data: SignedJson<serde_json::Value>, headers: 
 
 #[get("/nodeinfo/<version>")]
 pub fn nodeinfo(conn: DbConn, version: String) -> Result<Json<serde_json::Value>, ErrorPage> {
-    if version != "2.0" || version != "2.1" {
+    dbg!(&version);
+    if version != "2.0" && version != "2.1" {
         return Err(ErrorPage::from(Error::NotFound));
     }
 

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -218,7 +218,6 @@ pub fn shared_inbox(conn: DbConn, data: SignedJson<serde_json::Value>, headers: 
 
 #[get("/nodeinfo/<version>")]
 pub fn nodeinfo(conn: DbConn, version: String) -> Result<Json<serde_json::Value>, ErrorPage> {
-    dbg!(&version);
     if version != "2.0" && version != "2.1" {
         return Err(ErrorPage::from(Error::NotFound));
     }


### PR DESCRIPTION
Once we have test for the main crate, this should definitely be tested.