### PR TITLE
Added coloration for selections

### DIFF
--- a/static/css/_global.scss
+++ b/static/css/_global.scss
@@ -4,13 +4,24 @@ html, body {
  	background: $background;
  	color: $black;
  	font-family: $route159;
+        ::selection {
+		background: $lightpurple;
+        }
+	::-moz-selection {
+		background: $lightpurple;
+	}
 }
 
 a, a:visited {
  	color: $purple;
  	text-decoration: none;
 }
-
+a::selection { 
+	color: $white;
+}
+a::-moz-selection {
+	color: $white;
+}
 small {
  	margin-left: 1em;
  	color: transparentize($black, 0.6);

--- a/static/css/_variables.scss
+++ b/static/css/_variables.scss
@@ -1,5 +1,4 @@
 // Colors
-
 $background: #F4F4F4;
 $form-input-background: #FFFFFF;
 $gray: #E3E3E3;
@@ -7,6 +6,7 @@ $lightgray: #ECECEC;
 $black: #242424;
 $white: #F4F4F4;
 $purple: #7765E3;
+$lightpurple: #c2bbee;
 $red: #E92F2F;
 
 // Fonts


### PR DESCRIPTION
This PR adds background highlighting for selected text and makes the color of anchor elements in the selected portion switch to white so that the purple text of the anchor does not get lost in the purple of the selection. 

Shadowing was not implemented as it seemed to reduce readability. Perhaps having a text shadow that goes away upon selection would be better?