### PR TITLE
Caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ rev = "4a72ea2ec716cb0b26188fb00bccf2ef7d1e031c"
 [build-dependencies]
 ructe = "0.5.6"
 rsass = "0.9"
-plume-common = {path = "plume-common"}
 
 [features]
 default = ["postgres"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rev = "4a72ea2ec716cb0b26188fb00bccf2ef7d1e031c"
 [build-dependencies]
 ructe = "0.5.6"
 rsass = "0.9"
+plume-common = {path = "plume-common"}
 
 [features]
 default = ["postgres"]

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+extern crate plume_common;
 extern crate ructe;
 extern crate rsass;
 use ructe::*;
@@ -16,8 +17,11 @@ fn main() {
             .expect("Error during SCSS compilation")
     ).expect("Couldn't write CSS output");
 
+    let cache_id = plume_common::utils::random_hex();
     println!("cargo:rerun-if-changed=target/deploy/plume-front.wasm");
     copy("target/deploy/plume-front.wasm", "static/plume-front.wasm")
         .and_then(|_| read_to_string("target/deploy/plume-front.js"))
-        .and_then(|js| write("static/plume-front.js", js.replace("\"plume-front.wasm\"", "\"/static/plume-front.wasm\""))).ok();
+        .and_then(|js| write("static/plume-front.js", js.replace("\"plume-front.wasm\"", &format!("\"/static/cached/{}/plume-front.wasm\"", cache_id)))).ok();
+
+    println!("cargo:rustc-env=CACHE_ID={}", cache_id)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ Then try to restart Plume.
             routes::session::password_reset_form,
             routes::session::password_reset,
 
+            routes::plume_static_files,
             routes::static_files,
 
             routes::tags::tag,

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -5,6 +5,8 @@ use templates::Html;
 
 pub use askama_escape::escape;
 
+pub static CACHE_NAME: &str = env!("CACHE_ID");
+
 pub type BaseContext<'a> = &'a(&'a Connection, &'a Catalog, Option<User>);
 
 pub type Ructe = Content<Vec<u8>>;

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -1,6 +1,12 @@
 use plume_models::{Connection, notifications::*, users::User};
-use rocket::response::Content;
+
+use rocket::http::{Method, Status};
+use rocket::http::hyper::header::{ETag, EntityTag};
+use rocket::request::Request;
+use rocket::response::{self, Response, Responder, content::Html as HtmlCt};
 use rocket_i18n::Catalog;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hasher;
 use templates::Html;
 
 pub use askama_escape::escape;
@@ -9,13 +15,36 @@ pub static CACHE_NAME: &str = env!("CACHE_ID");
 
 pub type BaseContext<'a> = &'a(&'a Connection, &'a Catalog, Option<User>);
 
-pub type Ructe = Content<Vec<u8>>;
+#[derive(Debug)]
+pub struct Ructe(pub Vec<u8>);
+
+impl<'r> Responder<'r> for Ructe {
+    fn respond_to(self, r: &Request) -> response::Result<'r> {
+        //if method is not Get or page contain a form, no caching
+        if r.method() != Method::Get || self.0.windows(6).any(|w| w == b"<form ") {
+            return HtmlCt(self.0).respond_to(r);
+        }
+        let mut hasher = DefaultHasher::new();
+        hasher.write(&self.0);
+        let etag = format!("{:x}", hasher.finish());
+        if r.headers().get("If-None-Match").any(|s| &s[1..s.len()-1] == etag) {
+            Response::build()
+                .status(Status::NotModified)
+                .header(ETag(EntityTag::strong(etag)))
+                .ok()
+        } else {
+            Response::build()
+                .merge(HtmlCt(self.0).respond_to(r)?)
+                .header(ETag(EntityTag::strong(etag)))
+                .ok()
+        }
+    }
+}
 
 #[macro_export]
 macro_rules! render {
     ($group:tt :: $page:tt ( $( $param:expr ),* ) ) => {
         {
-            use rocket::{http::ContentType, response::Content};
             use templates;
 
             let mut res = vec![];
@@ -25,7 +54,7 @@ macro_rules! render {
                     $param
                 ),*
             ).unwrap();
-            Content(ContentType::HTML, res)
+            Ructe(res)
         }
     }
 }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -1,8 +1,8 @@
 /* color palette: https://coolors.co/23f0c7-ef767a-7765e3-6457a6-ffe347 */
 
-@import url('/static/fonts/Route159/Route159.css');
-@import url('/static/fonts/Lora/Lora.css');
-@import url('/static/fonts/Playfair_Display/PlayfairDisplay.css');
+@import url('../fonts/Route159/Route159.css');
+@import url('../fonts/Lora/Lora.css');
+@import url('../fonts/Playfair_Display/PlayfairDisplay.css');
 
 html {
   box-sizing: border-box;

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -8,10 +8,10 @@
         <meta charset="utf-8" />
         <title>@title ⋅ @i18n!(ctx.1, "Plume")</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="stylesheet" href="@uri!(static_files: file = "css/main.css")" />
-        <link rel="stylesheet" href="@uri!(static_files: file = "css/feather.css")" />
+        <link rel="stylesheet" href="@uri!(plume_static_files: file = "css/main.css", _build_id = CACHE_NAME)" />
+        <link rel="stylesheet" href="@uri!(plume_static_files: file = "css/feather.css", _build_id = CACHE_NAME)" />
         <link rel="manifest" href="@uri!(instance::web_manifest)" />
-        <link rel="icon" type="image/png" href="@uri!(static_files: file = "icons/trwnh/feather-filled/plumeFeatherFilled64.png")">
+        <link rel="icon" type="image/png" href="@uri!(plume_static_files: file = "icons/trwnh/feather-filled/plumeFeatherFilled64.png", _build_id = CACHE_NAME)">
         @:head()
     </head>
     <body>
@@ -22,7 +22,7 @@
             <div id="content">
                 <nav>
                     <a href="@uri!(instance::index)" class="title">
-                        <img src="@uri!(static_files: file = "icons/trwnh/feather/plumeFeather256.png")">
+                        <img src="@uri!(plume_static_files: file = "icons/trwnh/feather/plumeFeather256.png", _build_id = CACHE_NAME)">
                         <p>@i18n!(ctx.1, "Plume")</p>
                     </a>
                     <hr/>
@@ -79,6 +79,6 @@
                 <a href="@uri!(instance::admin)">@i18n!(ctx.1, "Administration")</a>
             }
         </footer>
-        <script src="@uri!(static_files: file = "plume-front.js")"></script>
+        <script src="@uri!(plume_static_files: file = "plume-front.js", _build_id = CACHE_NAME)"></script>
     </body>
 </html>


### PR DESCRIPTION
Try to cache static resources.
Static non media file's timestamps are hashed at compile tome so that modifying them invalidate old cache.
~~For some reason, plume-front.wasm isn't loaded from cache, even if it contains the right headers.~~ 
I changed nothing and now it is? I guess I'm ok with it
~~I'll look into adding Etag support too~~
All response made from templates and not containing a form are now Etag-cached