### PR TITLE
Print help when subcommand is given without arguments

### DIFF
--- a/plume-cli/src/instance.rs
+++ b/plume-cli/src/instance.rs
@@ -33,6 +33,7 @@ pub fn run<'a>(args: &ArgMatches<'a>, conn: &Connection) {
     let conn = conn;
     match args.subcommand() {
         ("new", Some(x)) => new(x, conn),
+        ("", None) => command().print_help().unwrap(),
         _ => println!("Unknown subcommand"),
     }
 }

--- a/plume-cli/src/search.rs
+++ b/plume-cli/src/search.rs
@@ -59,6 +59,7 @@ pub fn run<'a>(args: &ArgMatches<'a>, conn: &Connection) {
         ("init", Some(x)) => init(x, conn),
         ("refill", Some(x)) => refill(x, conn, None),
         ("unlock", Some(x)) => unlock(x),
+        ("", None) => command().print_help().unwrap(),
         _ => println!("Unknown subcommand"),
     }
 }

--- a/plume-cli/src/users.rs
+++ b/plume-cli/src/users.rs
@@ -80,6 +80,7 @@ pub fn run<'a>(args: &ArgMatches<'a>, conn: &Connection) {
     match args.subcommand() {
         ("new", Some(x)) => new(x, conn),
         ("reset-password", Some(x)) => reset_password(x, conn),
+        ("", None) => command().print_help().unwrap(),
         _ => println!("Unknown subcommand"),
     }
 }


### PR DESCRIPTION
Fix #490