### PR TITLE
Delete notifications when deleting comments

### DIFF
--- a/plume-models/src/comments.rs
+++ b/plume-models/src/comments.rs
@@ -330,10 +330,14 @@ impl<'a> Deletable<Connection, Delete> for Comment {
         act.object_props
             .set_to_link_vec(vec![Id::new(PUBLIC_VISIBILTY)])?;
 
-        for m in Mention::list_for_comment(&conn, self.id)? {
+        for m in Mention::list_for_comment(conn, self.id)? {
+            for n in Notification::find_for_mention(conn, &m)? {
+                n.delete(conn)?;
+            }
             m.delete(conn)?;
         }
-        for n in Notification::find_for_comment(&conn, &self)? {
+
+        for n in Notification::find_for_comment(conn, &self)? {
             n.delete(conn)?;
         }
 

--- a/plume-models/src/comments.rs
+++ b/plume-models/src/comments.rs
@@ -333,6 +333,10 @@ impl<'a> Deletable<Connection, Delete> for Comment {
         for m in Mention::list_for_comment(&conn, self.id)? {
             m.delete(conn)?;
         }
+        for n in Notification::find_for_comment(&conn, &self)? {
+            n.delete(conn)?;
+        }
+
         diesel::update(comments::table)
             .filter(comments::in_response_to_id.eq(self.id))
             .set(comments::in_response_to_id.eq(self.in_response_to_id))

--- a/plume-models/src/config.rs
+++ b/plume-models/src/config.rs
@@ -59,7 +59,7 @@ fn get_rocket_config() -> Result<RocketConfig, RocketError> {
 pub struct LogoConfig {
     pub main: String,
     pub favicon: String,
-    pub other: Vec<Icon> //url, size, type
+    pub other: Vec<Icon>, //url, size, type
 }
 
 #[derive(Serialize)]
@@ -82,14 +82,12 @@ impl Icon {
     }
 }
 
-
-
 impl Default for LogoConfig {
     fn default() -> Self {
         let to_icon = |(src, sizes, image_type): &(&str, Option<&str>, Option<&str>)| Icon {
             src: str::to_owned(src),
             sizes: sizes.map(str::to_owned),
-            image_type: image_type.map(str::to_owned)
+            image_type: image_type.map(str::to_owned),
         };
         let icons = [
             (
@@ -132,29 +130,34 @@ impl Default for LogoConfig {
                 Some("512x512"),
                 Some("image/png"),
             ),
-            (
-                "icons/trwnh/feather/plumeFeather.svg",
-                None,
-                None,
-            )
-        ].iter().map(to_icon).collect();
+            ("icons/trwnh/feather/plumeFeather.svg", None, None),
+        ]
+        .iter()
+        .map(to_icon)
+        .collect();
 
         let custom_main = var("PLUME_LOGO").ok();
-        let custom_favicon = var("PLUME_LOGO_FAVICON").ok().or_else(|| custom_main.clone());
+        let custom_favicon = var("PLUME_LOGO_FAVICON")
+            .ok()
+            .or_else(|| custom_main.clone());
         let other = if let Some(main) = custom_main.clone() {
             let ext = |path: &str| match path.rsplitn(2, '.').next() {
                 Some("png") => Some("image/png".to_owned()),
-                Some("jpg")| Some("jpeg") => Some("image/jpeg".to_owned()),
+                Some("jpg") | Some("jpeg") => Some("image/jpeg".to_owned()),
                 Some("svg") => Some("image/svg+xml".to_owned()),
                 Some("webp") => Some("image/webp".to_owned()),
                 _ => None,
             };
             let mut custom_icons = env::vars()
-                .filter_map(|(var, val)| if var.starts_with("PLUME_LOGO_") {
-                    Some((var[11..].to_owned(), val))
-                } else { None })
-                .filter_map(|(var, val)| var.parse::<u64>().ok().map(|var| (var,val)))
-                .map(|(dim,src)| Icon {
+                .filter_map(|(var, val)| {
+                    if var.starts_with("PLUME_LOGO_") {
+                        Some((var[11..].to_owned(), val))
+                    } else {
+                        None
+                    }
+                })
+                .filter_map(|(var, val)| var.parse::<u64>().ok().map(|var| (var, val)))
+                .map(|(dim, src)| Icon {
                     image_type: ext(&src),
                     src,
                     sizes: Some(format!("{}x{}", dim, dim)),
@@ -171,8 +174,11 @@ impl Default for LogoConfig {
         };
 
         LogoConfig {
-            main: custom_main.unwrap_or_else(|| "icons/trwnh/feather/plumeFeather256.png".to_owned()),
-            favicon: custom_favicon.unwrap_or_else(|| "icons/trwnh/feather-filled/plumeFeatherFilled64.png".to_owned()),
+            main: custom_main
+                .unwrap_or_else(|| "icons/trwnh/feather/plumeFeather256.png".to_owned()),
+            favicon: custom_favicon.unwrap_or_else(|| {
+                "icons/trwnh/feather-filled/plumeFeatherFilled64.png".to_owned()
+            }),
             other,
         }
     }

--- a/plume-models/src/notifications.rs
+++ b/plume-models/src/notifications.rs
@@ -48,6 +48,15 @@ impl Notification {
             .map_err(Error::from)
     }
 
+    pub fn find_for_comment(conn: &Connection, comment: &Comment) -> Result<Vec<Notification>> {
+        notifications::table
+            .filter(notifications::kind.eq(notification_kind::COMMENT))
+            .filter(notifications::object_id.eq(comment.id))
+            .order_by(notifications::creation_date.desc())
+            .load::<Notification>(conn)
+            .map_err(Error::from)
+    }
+
     pub fn count_for_user(conn: &Connection, user: &User) -> Result<i64> {
         notifications::table
             .filter(notifications::user_id.eq(user.id))

--- a/plume-models/src/notifications.rs
+++ b/plume-models/src/notifications.rs
@@ -48,11 +48,18 @@ impl Notification {
             .map_err(Error::from)
     }
 
+    pub fn find_for_mention(conn: &Connection, mention: &Mention) -> Result<Vec<Notification>> {
+        notifications::table
+            .filter(notifications::kind.eq(notification_kind::MENTION))
+            .filter(notifications::object_id.eq(mention.id))
+            .load::<Notification>(conn)
+            .map_err(Error::from)
+    }
+
     pub fn find_for_comment(conn: &Connection, comment: &Comment) -> Result<Vec<Notification>> {
         notifications::table
             .filter(notifications::kind.eq(notification_kind::COMMENT))
             .filter(notifications::object_id.eq(comment.id))
-            .order_by(notifications::creation_date.desc())
             .load::<Notification>(conn)
             .map_err(Error::from)
     }

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -7,7 +7,11 @@ use validator::Validate;
 use std::time::Duration;
 
 use plume_common::{
-    activity_pub::{broadcast, inbox::Deletable, ActivityStream, ApRequest},
+    activity_pub::{
+        broadcast,
+        inbox::{Deletable, Notify},
+        ActivityStream, ApRequest,
+    },
     utils,
 };
 use plume_models::{
@@ -60,6 +64,7 @@ pub fn create(
                 },
             )
             .expect("comments::create: insert error");
+            comm.notify(&*conn).expect("comments::create: notify error");
             let new_comment = comm
                 .create_activity(&*conn)
                 .expect("comments::create: activity error");
@@ -70,8 +75,8 @@ pub fn create(
                     &*conn,
                     &Mention::build_activity(&*conn, &ment)
                         .expect("comments::create: build mention error"),
-                    post.id,
-                    true,
+                    comm.id,
+                    false,
                     true,
                 )
                 .expect("comments::create: mention save error");


### PR DESCRIPTION
This PR implements a new function `find_for_comment` on `Notification` to list all notifications for a specific comment. The `delete` function on `Comment` is changed to list and delete all connected notifications.

I wasn't able to test the changes yet since I don't have the test environment set up, so the PR is `WIP` for now.

This should close #463 and close #500.