### PR TITLE
Fix issue with sqlite migrations for comment_seers

### DIFF
--- a/migrations/sqlite/2019-03-25-205630_fix-comment-seers/down.sql
+++ b/migrations/sqlite/2019-03-25-205630_fix-comment-seers/down.sql
@@ -1,0 +1,15 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE comment_seers RENAME TO tmp_comment_seers;
+
+CREATE TABLE comment_seers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    comment_id INTEGER REFERENCES comments(id) ON DELETE CASCADE NOT NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    UNIQUE (comment_id, user_id)
+);
+
+INSERT INTO comment_seers(id, comment_id, user_id)
+SELECT id, comment_id, user_id
+FROM tmp_comment_seers;
+
+DROP TABLE tmp_comment_seers;

--- a/migrations/sqlite/2019-03-25-205630_fix-comment-seers/up.sql
+++ b/migrations/sqlite/2019-03-25-205630_fix-comment-seers/up.sql
@@ -1,0 +1,16 @@
+-- Your SQL goes here
+ALTER TABLE comment_seers RENAME TO tmp_comment_seers;
+
+CREATE TABLE comment_seers (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    comment_id INTEGER REFERENCES comments(id) ON DELETE CASCADE NOT NULL,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    UNIQUE (comment_id, user_id)
+);
+
+INSERT INTO comment_seers(id, comment_id, user_id)
+SELECT id, comment_id, user_id
+FROM tmp_comment_seers
+WHERE id NOT NULL;
+
+DROP TABLE tmp_comment_seers;


### PR DESCRIPTION
This fixes the issue in the sqlite migrations for `comment_seers`.

The temporary workaround was to change the `id` column from `id INTEGER PRIMARY KEY AUTOINCREMENT` to `id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT`.

This change renames the table, creates a new table with the correct attributes, copies the old table over in the new one and deletes the old one.