### PR TITLE
Add some feedback when performing some actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plume"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "activitypub 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "askama_escape 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1797,9 +1797,9 @@ dependencies = [
  "lettre_email 0.9.0 (git+https://github.com/lettre/lettre?rev=c988b1760ad8179d9e7f3fb8594d2b86cf2a0a49)",
  "multipart 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "plume-api 0.2.0",
- "plume-common 0.2.0",
- "plume-models 0.2.0",
+ "plume-api 0.3.0",
+ "plume-common 0.3.0",
+ "plume-models 0.3.0",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_csrf 0.1.0 (git+https://github.com/fdb-hiroshima/rocket_csrf?rev=4a72ea2ec716cb0b26188fb00bccf2ef7d1e031c)",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "plume-api"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "canapi 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1828,18 +1828,18 @@ dependencies = [
 
 [[package]]
 name = "plume-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "plume-models 0.2.0",
+ "plume-models 0.3.0",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "plume-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "activitypub 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "activitystreams-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "plume-front"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "gettext 0.3.0 (git+https://github.com/Plume-org/gettext/?rev=294c54d74c699fbc66502b480a37cc66c1daa7f3)",
  "gettext-macros 0.4.0 (git+https://github.com/Plume-org/gettext-macros/?rev=a7c605f7edd6bfbfbfe7778026bfefd88d82db10)",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "plume-models"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "activitypub 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ammonia 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1885,10 +1885,10 @@ dependencies = [
  "guid-create 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "plume-api 0.2.0",
- "plume-common 0.2.0",
+ "plume-api 0.3.0",
+ "plume-common 0.3.0",
  "reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_i18n 0.4.0 (git+https://github.com/Plume-org/rocket_i18n?rev=e922afa7c366038b3433278c03b1456b346074f2)",

--- a/plume-models/src/plume_rocket.rs
+++ b/plume-models/src/plume_rocket.rs
@@ -6,7 +6,7 @@ mod module {
     use crate::search;
     use crate::users;
     use rocket::{
-        request::{self, FromRequest, Request},
+        request::{self, FlashMessage, FromRequest, Request},
         Outcome, State,
     };
     use scheduled_thread_pool::ScheduledThreadPool;
@@ -19,6 +19,7 @@ mod module {
         pub user: Option<users::User>,
         pub searcher: Arc<search::Searcher>,
         pub worker: Arc<ScheduledThreadPool>,
+        pub flash_msg: Option<(String, String)>,
     }
 
     impl<'a, 'r> FromRequest<'a, 'r> for PlumeRocket {
@@ -30,10 +31,12 @@ mod module {
             let user = request.guard::<users::User>().succeeded();
             let worker = request.guard::<State<Arc<ScheduledThreadPool>>>()?;
             let searcher = request.guard::<State<Arc<search::Searcher>>>()?;
+            let flash_msg = request.guard::<FlashMessage>().succeeded();
             Outcome::Success(PlumeRocket {
                 conn,
                 intl,
                 user,
+                flash_msg: flash_msg.map(|f| (f.name().into(), f.msg().into())),
                 worker: worker.clone(),
                 searcher: searcher.clone(),
             })

--- a/po/plume/ar.po
+++ b/po/plume/ar.po
@@ -49,6 +49,15 @@ msgstr "لإنشاء مدونة جديدة، تحتاج إلى تسجيل الد
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "تمت إعادة تعيين كلمتك السرية بنجاح."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "لا يسمح لك بحذف هذه المدونة."
@@ -65,9 +74,55 @@ msgstr "لا يمكنك استخدام هذه الوسائط كأيقونة لل
 msgid "You can't use this media as a blog banner."
 msgstr "لا يمكنك استخدام هذه الوسائط كشعار للمدونة."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "ليس لديك أية وسائط بعد."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "ليس لديك أية وسائط بعد."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "يجب عليك تسجيل الدخول أولا للإعجاب بهذا المقال"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "لا يسمح لك بحذف هذه المدونة."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "لا يسمح لك بتعديل هذه المدونة."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -93,6 +148,34 @@ msgstr "منشور جديد"
 msgid "Edit {0}"
 msgstr "تعديل {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "لا يسمح لك بتعديل هذه المدونة."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "ليس لديك أية وسائط بعد."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "لا يسمح لك بحذف هذه المدونة."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -102,6 +185,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "ليست لديك التصريحات اللازمة للقيام بذلك."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "ليست لديك التصريحات اللازمة للقيام بذلك."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -123,12 +214,41 @@ msgstr "عذراً، ولكن انتهت مدة صلاحية الرابط. حا�
 msgid "To access your dashboard, you need to be logged in"
 msgstr "يجب عليك تسجيل الدخول أولاللنفاذ إلى لوح المراقبة"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "ليس لديك أية وسائط بعد."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/ar.po
+++ b/po/plume/ar.po
@@ -265,10 +265,10 @@ msgid "Follow {}"
 msgstr "اتبع"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "قم بتسجيل الدخول قصد مشاركته"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/bg.po
+++ b/po/plume/bg.po
@@ -262,10 +262,10 @@ msgstr "Писти Pluma {0}"
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/bg.po
+++ b/po/plume/bg.po
@@ -48,6 +48,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr "Вече съществува блог със същото име."
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -64,9 +72,55 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Вие не сте автор на този блог."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Вие не сте автор на този блог."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +146,34 @@ msgstr "Нова публикация"
 msgid "Edit {0}"
 msgstr ""
 
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Вие не сте автор на този блог."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Вие не сте автор на този блог."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +183,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Не сте упълномощени."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Не сте упълномощени."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,12 +212,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/ca.po
+++ b/po/plume/ca.po
@@ -48,6 +48,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -64,8 +72,52 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
+msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/medias.rs:145
+msgid "You are not allowed to delete this media."
+msgstr ""
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/medias.rs:156
+msgid "You are not allowed to use this media."
 msgstr ""
 
 # src/routes/notifications.rs:29
@@ -92,6 +144,32 @@ msgstr "Apunt nou"
 msgid "Edit {0}"
 msgstr ""
 
+# src/routes/posts.rs:264
+msgid "You are not allowed to publish on this blog."
+msgstr ""
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:565
+msgid "You are not allowed to delete this article."
+msgstr ""
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -100,6 +178,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -122,12 +208,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/ca.po
+++ b/po/plume/ca.po
@@ -262,10 +262,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/cs.po
+++ b/po/plume/cs.po
@@ -48,6 +48,15 @@ msgstr "Pro vytvoření nového blogu musíte být přihlášeni"
 msgid "A blog with the same name already exists."
 msgstr "Blog s rovnakým názvem již existuje."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Vaše heslo bylo úspěšně obnoveno."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Nemáte oprávnění zmazat tento blog."
@@ -64,9 +73,55 @@ msgstr "Toto médium nelze použít jako ikonu blogu."
 msgid "You can't use this media as a blog banner."
 msgstr "Toto médium nelze použít jako banner blogu."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Zatím nemáte nahrané žádné média."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Zatím nemáte nahrané žádné média."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Pro oblíbení příspěvku musíte být přihlášen/a"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Nemáte oprávnění zmazat tento blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Nemáte oprávnění upravovat tento blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nový příspěvek"
 msgid "Edit {0}"
 msgstr "Upravit {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Nemáte oprávnění upravovat tento blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Zatím nemáte nahrané žádné média."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Nemáte oprávnění zmazat tento blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +186,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Pro sdílení příspěvku musíte být přihlášeni"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Nemáte oprávnění."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Nemáte oprávnění."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,6 +215,14 @@ msgstr "Omlouváme se, ale odkaz vypršel. Zkuste to znovu"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Pro přístup k vaší nástěnce musíte být přihlášen/a"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Chcete-li někoho odebírat, musíte být přihlášeni"
@@ -131,6 +230,27 @@ msgstr "Chcete-li někoho odebírat, musíte být přihlášeni"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Pro úpravu vášho profilu musíte být přihlášeni"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Zatím nemáte nahrané žádné média."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/cs.po
+++ b/po/plume/cs.po
@@ -264,10 +264,12 @@ msgstr "Beží na Plume {0}"
 msgid "Follow {}"
 msgstr "Následovat {}"
 
-msgid "Login to follow"
+#, fuzzy
+msgid "Log in to follow"
 msgstr "Pro následování se přihlášte"
 
-msgid "Enter your full username to follow"
+#, fuzzy
+msgid "Enter your full username handle to follow"
 msgstr "Pro následovaní zadejte své úplné uživatelské jméno"
 
 msgid "Edit your account"

--- a/po/plume/de.po
+++ b/po/plume/de.po
@@ -264,10 +264,10 @@ msgid "Follow {}"
 msgstr "Folgen"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Um zu boosten, musst du eingeloggt sein"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/de.po
+++ b/po/plume/de.po
@@ -48,6 +48,15 @@ msgstr "Um einen neuen Blog zu erstellen, müssen Sie angemeldet sein"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Dein Passwort wurde erfolgreich zurückgesetzt."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Sie dürfen diesen Blog nicht löschen."
@@ -64,9 +73,55 @@ msgstr "Sie können dieses Medium nicht als ein Blog-Icon verwenden."
 msgid "You can't use this media as a blog banner."
 msgstr "Sie können dieses Medium nicht als einen Blog-Banner verwenden."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Du hast noch keine Medien."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Du hast noch keine Medien."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Um einen Beitrag zu liken, musst du angemeldet sein"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Sie dürfen diesen Blog nicht löschen."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Ihnen fehlt die Berechtigung, um diesen Blog zu bearbeiten."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Neuer Beitrag"
 msgid "Edit {0}"
 msgstr "Bearbeite {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Ihnen fehlt die Berechtigung, um diesen Blog zu bearbeiten."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Du hast noch keine Medien."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Sie dürfen diesen Blog nicht löschen."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Um einen Beitrag zu wiederholen, musst du angemeldet sein"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Nicht berechtigt."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Nicht berechtigt."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,6 +213,14 @@ msgstr "Entschuldigung, der Link ist abgelaufen. Versuche es erneut"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Um auf dein Dashboard zuzugreifen, musst du angemeldet sein"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Um jemanden zu abonnieren, musst du angemeldet sein"
@@ -129,6 +228,27 @@ msgstr "Um jemanden zu abonnieren, musst du angemeldet sein"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Um dein Profil zu bearbeiten, musst du angemeldet sein"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Du hast noch keine Medien."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/en.po
+++ b/po/plume/en.po
@@ -48,6 +48,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -64,8 +72,52 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
+msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/medias.rs:145
+msgid "You are not allowed to delete this media."
+msgstr ""
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/medias.rs:156
+msgid "You are not allowed to use this media."
 msgstr ""
 
 # src/routes/notifications.rs:29
@@ -92,6 +144,32 @@ msgstr ""
 msgid "Edit {0}"
 msgstr ""
 
+# src/routes/posts.rs:264
+msgid "You are not allowed to publish on this blog."
+msgstr ""
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:565
+msgid "You are not allowed to delete this article."
+msgstr ""
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -100,6 +178,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -122,12 +208,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/en.po
+++ b/po/plume/en.po
@@ -262,10 +262,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/eo.po
+++ b/po/plume/eo.po
@@ -48,6 +48,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -64,9 +72,55 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Vi ne estas permesita redakti ĉi tiun blogon."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Vi ne estas permesita redakti ĉi tiun blogon."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +146,34 @@ msgstr "Nova skribaĵo"
 msgid "Edit {0}"
 msgstr ""
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Vi ne estas permesita redakti ĉi tiun blogon."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Vi ne estas permesita redakti ĉi tiun blogon."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -100,6 +182,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -122,12 +212,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/eo.po
+++ b/po/plume/eo.po
@@ -262,10 +262,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/es.po
+++ b/po/plume/es.po
@@ -264,10 +264,10 @@ msgid "Follow {}"
 msgstr "Seguir"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Dejar de seguir"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/es.po
+++ b/po/plume/es.po
@@ -48,6 +48,15 @@ msgstr "Para crear un nuevo blog, necesita estar logueado"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Su contraseña se ha restablecido correctamente."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "No está autorizado a eliminar este registro."
@@ -64,9 +73,55 @@ msgstr "No puede usar este medio como icono del blog."
 msgid "You can't use this media as a blog banner."
 msgstr "No puede usar este medio como bandera del blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Todavía no tiene ningún medio."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Todavía no tiene ningún medio."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Para darle un Me Gusta a un artículo, necesita estar conectado"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "No está autorizado a eliminar este registro."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "No tiene permiso para editar este blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nueva publicación"
 msgid "Edit {0}"
 msgstr "Editar {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "No tiene permiso para editar este blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Todavía no tiene ningún medio."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "No está autorizado a eliminar este registro."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Para compartir un artículo, necesita estar logueado"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "No está autorizado."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "No está autorizado."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,6 +213,14 @@ msgstr "Lo sentimos, pero el enlace expiró. Inténtalo de nuevo"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Para acceder a su panel de control, necesita estar conectado"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Para suscribirse a alguien, necesita estar conectado"
@@ -129,6 +228,27 @@ msgstr "Para suscribirse a alguien, necesita estar conectado"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Para editar su perfil, necesita estar conectado"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Todavía no tiene ningún medio."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/fr.po
+++ b/po/plume/fr.po
@@ -48,6 +48,15 @@ msgstr "Vous devez vous connecter pour créer un nouveau blog"
 msgid "A blog with the same name already exists."
 msgstr "Un blog avec le même nom existe déjà."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Votre mot de passe a été réinitialisé avec succès."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Vous n'êtes pas autorisé⋅e à supprimer ce blog."
@@ -64,9 +73,55 @@ msgstr "Vous ne pouvez pas utiliser ce media comme icône de blog."
 msgid "You can't use this media as a blog banner."
 msgstr "Vous ne pouvez pas utiliser ce media comme illustration de blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Vous n'avez pas encore de média."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Vous n'avez pas encore de média."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Vous devez vous connecter pour aimer un article"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Vous n'êtes pas autorisé⋅e à supprimer ce blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Vous n'êtes pas autorisé à éditer ce blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nouvel article"
 msgid "Edit {0}"
 msgstr "Modifier {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Vous n'êtes pas autorisé à éditer ce blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Vous n'avez pas encore de média."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Vous n'êtes pas autorisé⋅e à supprimer ce blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Vous devez vous connecter pour partager un article"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Vous n’avez pas les droits."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Vous n’avez pas les droits."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,6 +213,14 @@ msgstr "Désolé, mais le lien a expiré. Réessayez"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Vous devez vous connecter pour accéder à votre tableau de bord"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Vous devez vous connecter pour vous abonner à quelqu'un"
@@ -129,6 +228,27 @@ msgstr "Vous devez vous connecter pour vous abonner à quelqu'un"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Vous devez vous connecter pour pour modifier votre profil"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Vous n'avez pas encore de média."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/fr.po
+++ b/po/plume/fr.po
@@ -265,10 +265,10 @@ msgid "Follow {}"
 msgstr "S’abonner"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Connectez-vous pour partager"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/gl.po
+++ b/po/plume/gl.po
@@ -265,10 +265,10 @@ msgid "Follow {}"
 msgstr "Seguir"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Conéctese para promover"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/gl.po
+++ b/po/plume/gl.po
@@ -48,6 +48,15 @@ msgstr "Para crear un novo blog debe estar conectada"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "O contrasinal restableceuse correctamente."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Vostede non ten permiso para eliminar este blog."
@@ -64,9 +73,55 @@ msgstr "Vostede non pode utilizar este medio como icona do blog."
 msgid "You can't use this media as a blog banner."
 msgstr "Vostede non pode utilizar este medio como banner do blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Aínda non subeu ficheiros de medios."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Aínda non subeu ficheiros de medios."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Para darlle a gústame, debe estar conectada"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Vostede non ten permiso para eliminar este blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Vostede non pode editar este blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nova entrada"
 msgid "Edit {0}"
 msgstr "Editar {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Vostede non pode editar este blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Aínda non subeu ficheiros de medios."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Vostede non ten permiso para eliminar este blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Para compartir un artigo, debe estar conectada"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Non ten permiso."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Non ten permiso."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,6 +213,14 @@ msgstr "Lamentámolo, a ligazón caducou. Inténteo de novo"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Para acceder ao taboleiro, debe estar conectada"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Para suscribirse a un blog, debe estar conectada"
@@ -129,6 +228,27 @@ msgstr "Para suscribirse a un blog, debe estar conectada"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Para editar o seu perfil, debe estar conectada"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Aínda non subeu ficheiros de medios."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/hi.po
+++ b/po/plume/hi.po
@@ -48,6 +48,15 @@ msgstr "नया ब्लॉग बनाने के लिए आपको 
 msgid "A blog with the same name already exists."
 msgstr "ये नाम से पहले ही एक ब्लॉग है"
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "आपका पासवर्ड रिसेट कर दिया गया है"
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "आपको ये ब्लॉग डिलीट करने की अनुमति नहीं है"
@@ -64,9 +73,55 @@ msgstr "इस फोटो को ब्लॉग आइकॉन के लि
 msgid "You can't use this media as a blog banner."
 msgstr "इस media को blog banner के लिए इस्तेमाल नहीं कर सकते"
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Post को like करने के लिए आपको log in करना होगा"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "आपको ये ब्लॉग डिलीट करने की अनुमति नहीं है"
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "आपको ये ब्लॉग में बदलाव करने की अनुमति नहीं है"
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "नया post"
 msgid "Edit {0}"
 msgstr "Edit करें {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "आपको ये ब्लॉग में बदलाव करने की अनुमति नहीं है"
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "आपको ये ब्लॉग डिलीट करने की अनुमति नहीं है"
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +186,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Post reshare करने के लिए आपको log in करना होगा"
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
+msgstr ""
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,6 +215,14 @@ msgstr "क्षमा करें, लेकिन लिंक इस्त�
 msgid "To access your dashboard, you need to be logged in"
 msgstr "डैशबोर्ड पर जाने के लिए, लोग इन करें"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "सब्सक्राइब करने के लिए, लोग इन करें"
@@ -131,6 +230,27 @@ msgstr "सब्सक्राइब करने के लिए, लोग 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "प्रोफाइल में बदलाव करने के लिए, लोग इन करें"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "प्लूम"

--- a/po/plume/hi.po
+++ b/po/plume/hi.po
@@ -264,10 +264,10 @@ msgstr "Plume {0} का इस्तेमाल कर रहे हैं"
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/hr.po
+++ b/po/plume/hr.po
@@ -49,6 +49,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -65,9 +73,55 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Ti ne autor ovog bloga."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Ti ne autor ovog bloga."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -93,6 +147,34 @@ msgstr "Novi članak"
 msgid "Edit {0}"
 msgstr "Uredi {0}"
 
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Ti ne autor ovog bloga."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:140
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Ti ne autor ovog bloga."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +183,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -123,12 +213,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/hr.po
+++ b/po/plume/hr.po
@@ -263,10 +263,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/it.po
+++ b/po/plume/it.po
@@ -48,6 +48,15 @@ msgstr "Per creare un nuovo blog, devi avere effettuato l'accesso"
 msgid "A blog with the same name already exists."
 msgstr "Un blog con lo stesso nome esiste già."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "La tua password è stata reimpostata con successo."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Non ti è consentito di eliminare questo blog."
@@ -64,9 +73,55 @@ msgstr "Non puoi utilizzare questo media come icona del blog."
 msgid "You can't use this media as a blog banner."
 msgstr "Non puoi utilizzare questo media come copertina del blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Non hai ancora nessun media."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Non hai ancora nessun media."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Per mettere mi piace ad un post, devi avere effettuato l'accesso"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Non ti è consentito di eliminare questo blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Non ti è consentito modificare questo blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nuovo post"
 msgid "Edit {0}"
 msgstr "Modifica {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Non ti è consentito modificare questo blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Non hai ancora nessun media."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Non ti è consentito di eliminare questo blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Per ricondividere un post, devi avere effettuato l'accesso"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Non sei autorizzato."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Non sei autorizzato."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -122,6 +213,14 @@ msgstr "Spiacente, ma il collegamento è scaduto. Riprova"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Per accedere al tuo pannello, devi avere effettuato l'accesso"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Per iscriverti a qualcuno, devi avere effettuato l'accesso"
@@ -129,6 +228,27 @@ msgstr "Per iscriverti a qualcuno, devi avere effettuato l'accesso"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Per modificare il tuo profilo, devi avere effettuato l'accesso"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Non hai ancora nessun media."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/it.po
+++ b/po/plume/it.po
@@ -264,10 +264,10 @@ msgid "Follow {}"
 msgstr "Segui"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Accedi per boostare"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/ja.po
+++ b/po/plume/ja.po
@@ -267,10 +267,10 @@ msgid "Follow {}"
 msgstr "フォロー"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "ブーストするにはログインしてください"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/ja.po
+++ b/po/plume/ja.po
@@ -48,6 +48,15 @@ msgstr "新しいブログを作成するにはログインが必要です"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "パスワードが正常にリセットされました。"
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "このブログを削除する権限がありません。"
@@ -64,9 +73,55 @@ msgstr "このメディアはブログアイコンに使用できません。"
 msgid "You can't use this media as a blog banner."
 msgstr "このメディアはブログバナーに使用できません。"
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "メディアがまだありません。"
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "メディアがまだありません。"
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "投稿をいいねするにはログインが必要です"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "このブログを削除する権限がありません。"
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "このブログを編集する権限がありません。"
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "新しい投稿"
 msgid "Edit {0}"
 msgstr "{0} を編集"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "このブログを編集する権限がありません。"
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "メディアがまだありません。"
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "このブログを削除する権限がありません。"
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +184,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "投稿を再共有するにはログインが必要です"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "許可されていません。"
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "許可されていません。"
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -123,6 +214,14 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr "ダッシュボードにアクセスするにはログインが必要です"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "誰かをフォローするにはログインが必要です"
@@ -130,6 +229,27 @@ msgstr "誰かをフォローするにはログインが必要です"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "プロフィールを編集するにはログインが必要です"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "メディアがまだありません。"
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/nb.po
+++ b/po/plume/nb.po
@@ -46,6 +46,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr "Et innlegg med samme navn finnes allerede."
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 #, fuzzy
 msgid "You are not allowed to delete this blog."
 msgstr "Du er ikke denne bloggens forfatter."
@@ -62,9 +70,53 @@ msgstr "Du er ikke denne bloggens forfatter."
 msgid "You can't use this media as a blog banner."
 msgstr "Du er ikke denne bloggens forfatter."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:47
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Du er ikke denne bloggens forfatter."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Du er ikke denne bloggens forfatter."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -89,6 +141,32 @@ msgstr "Nytt innlegg"
 msgid "Edit {0}"
 msgstr "Kommentér \"{0}\""
 
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Du er ikke denne bloggens forfatter."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Du er ikke denne bloggens forfatter."
+
+#, fuzzy
+msgid "Your article have been deleted."
+msgstr "Ingen innlegg å vise enda."
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/user.rs:222
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -98,6 +176,14 @@ msgstr ""
 # src/routes/reshares.rs:47
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Det har du har ikke tilgang til."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Det har du har ikke tilgang til."
 
 #, fuzzy
 msgid "Password reset"
@@ -119,12 +205,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+#, fuzzy
+msgid "You are now following {}."
+msgstr "{0} har begynt å følge deg"
+
 # src/routes/user.rs:187
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:287
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"
@@ -949,10 +1064,6 @@ msgstr ""
 #~ msgstr "Én følger"
 
 #, fuzzy
-#~ msgid "{0} is now following you."
-#~ msgstr "{0} har begynt å følge deg"
-
-#, fuzzy
 #~ msgid "People {0} follows"
 #~ msgstr "Én følger"
 
@@ -965,10 +1076,6 @@ msgstr ""
 
 #~ msgid "Unfollow"
 #~ msgstr "Slutt å følge"
-
-#, fuzzy
-#~ msgid "No articles to see here yet."
-#~ msgstr "Ingen innlegg å vise enda."
 
 #~ msgid "New blog"
 #~ msgstr "Ny blogg"

--- a/po/plume/nb.po
+++ b/po/plume/nb.po
@@ -274,10 +274,10 @@ msgid "Follow {}"
 msgstr "Følg"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Logg inn"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/pl.po
+++ b/po/plume/pl.po
@@ -264,10 +264,11 @@ msgstr "Działa na Plume {0}"
 msgid "Follow {}"
 msgstr "Obserwuj {}"
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+#, fuzzy
+msgid "Enter your full username handle to follow"
 msgstr "Wpisz swoją pełną nazwę użytkownika, do naśladowania"
 
 msgid "Edit your account"

--- a/po/plume/pl.po
+++ b/po/plume/pl.po
@@ -50,6 +50,15 @@ msgstr "Aby utworzyć nowy blog, musisz być zalogowany"
 msgid "A blog with the same name already exists."
 msgstr "Blog o tej samej nazwie już istnieje."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Twoje hasło zostało pomyślnie zresetowane."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Nie masz uprawnień do usunięcia tego bloga."
@@ -66,9 +75,55 @@ msgstr "Nie możesz użyć tego nośnika jako ikony blogu."
 msgid "You can't use this media as a blog banner."
 msgstr "Nie możesz użyć tego nośnika jako banner na blogu."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Nie masz żadnej zawartości multimedialnej."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Nie masz żadnej zawartości multimedialnej."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Aby polubić post, musisz być zalogowany"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Nie masz uprawnień do usunięcia tego bloga."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Nie masz uprawnień edytować tego bloga."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -94,6 +149,34 @@ msgstr "Nowy wpis"
 msgid "Edit {0}"
 msgstr "Edytuj {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Nie masz uprawnień edytować tego bloga."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Nie masz żadnej zawartości multimedialnej."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Nie masz uprawnień do usunięcia tego bloga."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +186,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Aby udostępnić post, musisz być zalogowany"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Nie jesteś zalogowany."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Nie jesteś zalogowany."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,6 +215,14 @@ msgstr "Przepraszam, ale link wygasł. Spróbuj ponownie"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Aby uzyskać dostęp do panelu, musisz być zalogowany"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Aby subskrybować do kogoś, musisz być zalogowany"
@@ -131,6 +230,27 @@ msgstr "Aby subskrybować do kogoś, musisz być zalogowany"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Aby edytować swój profil, musisz być zalogowany"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Nie masz żadnej zawartości multimedialnej."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -44,6 +44,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -60,8 +68,52 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
+msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/medias.rs:145
+msgid "You are not allowed to delete this media."
+msgstr ""
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/medias.rs:156
+msgid "You are not allowed to use this media."
 msgstr ""
 
 # src/routes/notifications.rs:30
@@ -88,12 +140,44 @@ msgstr ""
 msgid "Edit {0}"
 msgstr ""
 
-# src/routes/posts.rs:636
+# src/routes/posts.rs:264
+msgid "You are not allowed to publish on this blog."
+msgstr ""
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:565
+msgid "You are not allowed to delete this article."
+msgstr ""
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid "It looks like the article you tried to delete doesn't exist. Maybe it is already gone?"
+msgstr ""
+
+# src/routes/posts.rs:637
 msgid "Couldn't obtain enough information about your account. Please make sure your username is correct."
 msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:182
@@ -116,12 +200,40 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:246
+# src/routes/user.rs:155
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:172
+msgid "You are now following {}."
+msgstr ""
+
+# src/routes/user.rs:250
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:348
+# src/routes/user.rs:352
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:392
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:413
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:475
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:493
+msgid "Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -12,63 +12,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-# src/template_utils.rs:98
+# src/template_utils.rs:102
 msgid "{0} commented on your article."
 msgstr ""
 
-# src/template_utils.rs:99
+# src/template_utils.rs:103
 msgid "{0} is subscribed to you."
 msgstr ""
 
-# src/template_utils.rs:100
+# src/template_utils.rs:104
 msgid "{0} liked your article."
 msgstr ""
 
-# src/template_utils.rs:101
+# src/template_utils.rs:105
 msgid "{0} mentioned you."
 msgstr ""
 
-# src/template_utils.rs:102
+# src/template_utils.rs:106
 msgid "{0} boosted your article."
 msgstr ""
 
-# src/template_utils.rs:138
+# src/template_utils.rs:142
 msgid "{0}'s avatar"
 msgstr ""
 
-# src/routes/blogs.rs:68
+# src/routes/blogs.rs:64
 msgid "To create a new blog, you need to be logged in"
 msgstr ""
 
-# src/routes/blogs.rs:110
+# src/routes/blogs.rs:106
 msgid "A blog with the same name already exists."
 msgstr ""
 
-# src/routes/blogs.rs:145
+# src/routes/blogs.rs:141
 msgid "Your blog was successfully created!"
 msgstr ""
 
-# src/routes/blogs.rs:173
+# src/routes/blogs.rs:163
 msgid "Your blog was deleted."
 msgstr ""
 
-# src/routes/blogs.rs:179
+# src/routes/blogs.rs:170
 msgid "You are not allowed to delete this blog."
 msgstr ""
 
-# src/routes/blogs.rs:228
+# src/routes/blogs.rs:218
 msgid "You are not allowed to edit this blog."
 msgstr ""
 
-# src/routes/blogs.rs:273
+# src/routes/blogs.rs:263
 msgid "You can't use this media as a blog icon."
 msgstr ""
 
-# src/routes/blogs.rs:291
+# src/routes/blogs.rs:281
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
-# src/routes/blogs.rs:324
+# src/routes/blogs.rs:314
 msgid "Your blog information have been updated."
 msgstr ""
 
@@ -80,19 +80,19 @@ msgstr ""
 msgid "Your comment have been deleted."
 msgstr ""
 
-# src/routes/instance.rs:147
+# src/routes/instance.rs:134
 msgid "Instance settings have been saved."
 msgstr ""
 
-# src/routes/instance.rs:188
+# src/routes/instance.rs:175
 msgid "{} have been unblocked."
 msgstr ""
 
-# src/routes/instance.rs:190
+# src/routes/instance.rs:177
 msgid "{} have been blocked."
 msgstr ""
 
-# src/routes/instance.rs:238
+# src/routes/instance.rs:221
 msgid "{} have been banned."
 msgstr ""
 
@@ -100,19 +100,19 @@ msgstr ""
 msgid "To like a post, you need to be logged in"
 msgstr ""
 
-# src/routes/medias.rs:152
+# src/routes/medias.rs:141
 msgid "Your media have been deleted."
 msgstr ""
 
-# src/routes/medias.rs:157
+# src/routes/medias.rs:146
 msgid "You are not allowed to delete this media."
 msgstr ""
 
-# src/routes/medias.rs:174
+# src/routes/medias.rs:163
 msgid "Your avatar have been updated."
 msgstr ""
 
-# src/routes/medias.rs:179
+# src/routes/medias.rs:168
 msgid "You are not allowed to use this media."
 msgstr ""
 
@@ -128,43 +128,43 @@ msgstr ""
 msgid "To write a new post, you need to be logged in"
 msgstr ""
 
-# src/routes/posts.rs:143
+# src/routes/posts.rs:139
 msgid "You are not an author of this blog."
 msgstr ""
 
-# src/routes/posts.rs:150
+# src/routes/posts.rs:146
 msgid "New post"
 msgstr ""
 
-# src/routes/posts.rs:195
+# src/routes/posts.rs:191
 msgid "Edit {0}"
 msgstr ""
 
-# src/routes/posts.rs:264
+# src/routes/posts.rs:260
 msgid "You are not allowed to publish on this blog."
 msgstr ""
 
-# src/routes/posts.rs:352
+# src/routes/posts.rs:348
 msgid "Your article have been updated."
 msgstr ""
 
-# src/routes/posts.rs:532
+# src/routes/posts.rs:528
 msgid "Your post have been saved."
 msgstr ""
 
-# src/routes/posts.rs:572
+# src/routes/posts.rs:568
 msgid "You are not allowed to delete this article."
 msgstr ""
 
-# src/routes/posts.rs:597
+# src/routes/posts.rs:593
 msgid "Your article have been deleted."
 msgstr ""
 
-# src/routes/posts.rs:602
+# src/routes/posts.rs:598
 msgid "It looks like the article you tried to delete doesn't exist. Maybe it is already gone?"
 msgstr ""
 
-# src/routes/posts.rs:642
+# src/routes/posts.rs:638
 msgid "Couldn't obtain enough information about your account. Please make sure your username is correct."
 msgstr ""
 
@@ -172,67 +172,67 @@ msgstr ""
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
 
-# src/routes/session.rs:111
+# src/routes/session.rs:112
 msgid "You are now connected."
 msgstr ""
 
-# src/routes/session.rs:130
+# src/routes/session.rs:131
 msgid "You are now logged off."
 msgstr ""
 
-# src/routes/session.rs:187
+# src/routes/session.rs:188
 msgid "Password reset"
 msgstr ""
 
-# src/routes/session.rs:188
+# src/routes/session.rs:189
 msgid "Here is the link to reset your password: {0}"
 msgstr ""
 
-# src/routes/session.rs:260
+# src/routes/session.rs:264
 msgid "Your password was successfully reset."
 msgstr ""
 
-# src/routes/session.rs:264
+# src/routes/session.rs:274
 msgid "Sorry, but the link expired. Try again"
 msgstr ""
 
-# src/routes/user.rs:138
+# src/routes/user.rs:136
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:160
+# src/routes/user.rs:158
 msgid "You are no longer following {}."
 msgstr ""
 
-# src/routes/user.rs:177
+# src/routes/user.rs:175
 msgid "You are now following {}."
 msgstr ""
 
-# src/routes/user.rs:257
+# src/routes/user.rs:255
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:365
+# src/routes/user.rs:357
 msgid "To edit your profile, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:407
+# src/routes/user.rs:399
 msgid "Your profile have been updated."
 msgstr ""
 
-# src/routes/user.rs:434
+# src/routes/user.rs:426
 msgid "Your account have been deleted."
 msgstr ""
 
-# src/routes/user.rs:439
+# src/routes/user.rs:432
 msgid "You can't delete someone else's account."
 msgstr ""
 
-# src/routes/user.rs:508
+# src/routes/user.rs:504
 msgid "Registrations are closed on this instance."
 msgstr ""
 
-# src/routes/user.rs:530
+# src/routes/user.rs:528
 msgid "Your account have been created. You just need to login before you can use it."
 msgstr ""
 
@@ -320,11 +320,11 @@ msgstr ""
 msgid "Nothing to see here yet. Try subscribing to more people."
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Name"
 msgstr ""
 
-# src/template_utils.rs:250
+# src/template_utils.rs:254
 msgid "Optional"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Long description"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Default article license"
 msgstr ""
 
@@ -386,11 +386,11 @@ msgstr ""
 msgid "Upload an avatar"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Display name"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Email"
 msgstr ""
 
@@ -439,15 +439,15 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Username"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Password"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Password confirmation"
 msgstr ""
 
@@ -538,71 +538,71 @@ msgstr ""
 msgid "Advanced search"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Article title matching these words"
 msgstr ""
 
 msgid "Title"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Subtitle matching these words"
 msgstr ""
 
 msgid "Subtitle - byline"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Content matching these words"
 msgstr ""
 
 msgid "Body content"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "From this date"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "To this date"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Containing these tags"
 msgstr ""
 
 msgid "Tags"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Posted on one of these instances"
 msgstr ""
 
 msgid "Instance domain"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Posted by one of these authors"
 msgstr ""
 
 msgid "Authors"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Posted on one of these blogs"
 msgstr ""
 
 msgid "Blog title"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Written in this language"
 msgstr ""
 
 msgid "Language"
 msgstr ""
 
-# src/template_utils.rs:335
+# src/template_utils.rs:339
 msgid "Published under this license"
 msgstr ""
 
@@ -624,11 +624,11 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "New password"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Confirmation"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "We sent a mail to the address you gave us, with a link to reset your password."
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "E-mail"
 msgstr ""
 
@@ -651,7 +651,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Username, or email"
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Classic editor (any changes will be lost)"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Subtitle"
 msgstr ""
 
@@ -683,15 +683,15 @@ msgstr ""
 msgid "Upload media"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Tags, separated by commas"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "License"
 msgstr ""
 
-# src/template_utils.rs:255
+# src/template_utils.rs:259
 msgid "Leave it empty to reserve all rights"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-# src/template_utils.rs:247
+# src/template_utils.rs:251
 msgid "Content warning"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "I'm from another instance"
 msgstr ""
 
-# src/template_utils.rs:255
+# src/template_utils.rs:259
 msgid "Example: user@plu.me"
 msgstr ""
 

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -12,63 +12,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-# src/template_utils.rs:73
+# src/template_utils.rs:98
 msgid "{0} commented on your article."
 msgstr ""
 
-# src/template_utils.rs:74
+# src/template_utils.rs:99
 msgid "{0} is subscribed to you."
 msgstr ""
 
-# src/template_utils.rs:75
+# src/template_utils.rs:100
 msgid "{0} liked your article."
 msgstr ""
 
-# src/template_utils.rs:76
+# src/template_utils.rs:101
 msgid "{0} mentioned you."
 msgstr ""
 
-# src/template_utils.rs:77
+# src/template_utils.rs:102
 msgid "{0} boosted your article."
 msgstr ""
 
-# src/template_utils.rs:113
+# src/template_utils.rs:138
 msgid "{0}'s avatar"
 msgstr ""
 
-# src/routes/blogs.rs:75
+# src/routes/blogs.rs:68
 msgid "To create a new blog, you need to be logged in"
 msgstr ""
 
-# src/routes/blogs.rs:118
+# src/routes/blogs.rs:110
 msgid "A blog with the same name already exists."
 msgstr ""
 
-# src/routes/blogs.rs:153
+# src/routes/blogs.rs:145
 msgid "Your blog was successfully created!"
 msgstr ""
 
-# src/routes/blogs.rs:185
+# src/routes/blogs.rs:173
 msgid "Your blog was deleted."
 msgstr ""
 
-# src/routes/blogs.rs:191
+# src/routes/blogs.rs:179
 msgid "You are not allowed to delete this blog."
 msgstr ""
 
-# src/routes/blogs.rs:240
+# src/routes/blogs.rs:228
 msgid "You are not allowed to edit this blog."
 msgstr ""
 
-# src/routes/blogs.rs:286
+# src/routes/blogs.rs:273
 msgid "You can't use this media as a blog icon."
 msgstr ""
 
-# src/routes/blogs.rs:304
+# src/routes/blogs.rs:291
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
-# src/routes/blogs.rs:337
+# src/routes/blogs.rs:324
 msgid "Your blog information have been updated."
 msgstr ""
 
@@ -80,19 +80,19 @@ msgstr ""
 msgid "Your comment have been deleted."
 msgstr ""
 
-# src/routes/instance.rs:162
+# src/routes/instance.rs:147
 msgid "Instance settings have been saved."
 msgstr ""
 
-# src/routes/instance.rs:205
+# src/routes/instance.rs:188
 msgid "{} have been unblocked."
 msgstr ""
 
-# src/routes/instance.rs:207
+# src/routes/instance.rs:190
 msgid "{} have been blocked."
 msgstr ""
 
-# src/routes/instance.rs:257
+# src/routes/instance.rs:238
 msgid "{} have been banned."
 msgstr ""
 
@@ -100,71 +100,71 @@ msgstr ""
 msgid "To like a post, you need to be logged in"
 msgstr ""
 
-# src/routes/medias.rs:157
+# src/routes/medias.rs:152
 msgid "Your media have been deleted."
 msgstr ""
 
-# src/routes/medias.rs:162
+# src/routes/medias.rs:157
 msgid "You are not allowed to delete this media."
 msgstr ""
 
-# src/routes/medias.rs:179
+# src/routes/medias.rs:174
 msgid "Your avatar have been updated."
 msgstr ""
 
-# src/routes/medias.rs:184
+# src/routes/medias.rs:179
 msgid "You are not allowed to use this media."
 msgstr ""
 
-# src/routes/notifications.rs:33
+# src/routes/notifications.rs:28
 msgid "To see your notifications, you need to be logged in"
 msgstr ""
 
-# src/routes/posts.rs:94
+# src/routes/posts.rs:93
 msgid "This post isn't published yet."
 msgstr ""
 
-# src/routes/posts.rs:123
+# src/routes/posts.rs:122
 msgid "To write a new post, you need to be logged in"
 msgstr ""
 
-# src/routes/posts.rs:146
+# src/routes/posts.rs:143
 msgid "You are not an author of this blog."
 msgstr ""
 
-# src/routes/posts.rs:153
+# src/routes/posts.rs:150
 msgid "New post"
 msgstr ""
 
-# src/routes/posts.rs:199
+# src/routes/posts.rs:195
 msgid "Edit {0}"
 msgstr ""
 
-# src/routes/posts.rs:269
+# src/routes/posts.rs:264
 msgid "You are not allowed to publish on this blog."
 msgstr ""
 
-# src/routes/posts.rs:357
+# src/routes/posts.rs:352
 msgid "Your article have been updated."
 msgstr ""
 
-# src/routes/posts.rs:538
+# src/routes/posts.rs:532
 msgid "Your post have been saved."
 msgstr ""
 
-# src/routes/posts.rs:579
+# src/routes/posts.rs:572
 msgid "You are not allowed to delete this article."
 msgstr ""
 
-# src/routes/posts.rs:604
+# src/routes/posts.rs:597
 msgid "Your article have been deleted."
 msgstr ""
 
-# src/routes/posts.rs:609
+# src/routes/posts.rs:602
 msgid "It looks like the article you tried to delete doesn't exist. Maybe it is already gone?"
 msgstr ""
 
-# src/routes/posts.rs:653
+# src/routes/posts.rs:642
 msgid "Couldn't obtain enough information about your account. Please make sure your username is correct."
 msgstr ""
 
@@ -172,67 +172,67 @@ msgstr ""
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
 
-# src/routes/session.rs:116
+# src/routes/session.rs:111
 msgid "You are now connected."
 msgstr ""
 
-# src/routes/session.rs:135
+# src/routes/session.rs:130
 msgid "You are now logged off."
 msgstr ""
 
-# src/routes/session.rs:194
+# src/routes/session.rs:187
 msgid "Password reset"
 msgstr ""
 
-# src/routes/session.rs:195
+# src/routes/session.rs:188
 msgid "Here is the link to reset your password: {0}"
 msgstr ""
 
-# src/routes/session.rs:275
+# src/routes/session.rs:260
 msgid "Your password was successfully reset."
 msgstr ""
 
-# src/routes/session.rs:279
+# src/routes/session.rs:264
 msgid "Sorry, but the link expired. Try again"
 msgstr ""
 
-# src/routes/user.rs:142
+# src/routes/user.rs:138
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:164
+# src/routes/user.rs:160
 msgid "You are no longer following {}."
 msgstr ""
 
-# src/routes/user.rs:181
+# src/routes/user.rs:177
 msgid "You are now following {}."
 msgstr ""
 
-# src/routes/user.rs:262
+# src/routes/user.rs:257
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:375
+# src/routes/user.rs:365
 msgid "To edit your profile, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:417
+# src/routes/user.rs:407
 msgid "Your profile have been updated."
 msgstr ""
 
-# src/routes/user.rs:445
+# src/routes/user.rs:434
 msgid "Your account have been deleted."
 msgstr ""
 
-# src/routes/user.rs:450
+# src/routes/user.rs:439
 msgid "You can't delete someone else's account."
 msgstr ""
 
-# src/routes/user.rs:520
+# src/routes/user.rs:508
 msgid "Registrations are closed on this instance."
 msgstr ""
 
-# src/routes/user.rs:542
+# src/routes/user.rs:530
 msgid "Your account have been created. You just need to login before you can use it."
 msgstr ""
 
@@ -320,11 +320,11 @@ msgstr ""
 msgid "Nothing to see here yet. Try subscribing to more people."
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Name"
 msgstr ""
 
-# src/template_utils.rs:225
+# src/template_utils.rs:250
 msgid "Optional"
 msgstr ""
 
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Long description"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Default article license"
 msgstr ""
 
@@ -386,11 +386,11 @@ msgstr ""
 msgid "Upload an avatar"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Display name"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Email"
 msgstr ""
 
@@ -439,15 +439,15 @@ msgstr ""
 msgid "Create an account"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Username"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Password"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Password confirmation"
 msgstr ""
 
@@ -538,71 +538,71 @@ msgstr ""
 msgid "Advanced search"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Article title matching these words"
 msgstr ""
 
 msgid "Title"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Subtitle matching these words"
 msgstr ""
 
 msgid "Subtitle - byline"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Content matching these words"
 msgstr ""
 
 msgid "Body content"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "From this date"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "To this date"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Containing these tags"
 msgstr ""
 
 msgid "Tags"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Posted on one of these instances"
 msgstr ""
 
 msgid "Instance domain"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Posted by one of these authors"
 msgstr ""
 
 msgid "Authors"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Posted on one of these blogs"
 msgstr ""
 
 msgid "Blog title"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Written in this language"
 msgstr ""
 
 msgid "Language"
 msgstr ""
 
-# src/template_utils.rs:310
+# src/template_utils.rs:335
 msgid "Published under this license"
 msgstr ""
 
@@ -624,11 +624,11 @@ msgstr ""
 msgid "Reset your password"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "New password"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Confirmation"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "We sent a mail to the address you gave us, with a link to reset your password."
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "E-mail"
 msgstr ""
 
@@ -651,7 +651,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Username, or email"
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Classic editor (any changes will be lost)"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Subtitle"
 msgstr ""
 
@@ -683,15 +683,15 @@ msgstr ""
 msgid "Upload media"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Tags, separated by commas"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "License"
 msgstr ""
 
-# src/template_utils.rs:230
+# src/template_utils.rs:255
 msgid "Leave it empty to reserve all rights"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-# src/template_utils.rs:222
+# src/template_utils.rs:247
 msgid "Content warning"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "I'm from another instance"
 msgstr ""
 
-# src/template_utils.rs:230
+# src/template_utils.rs:255
 msgid "Example: user@plu.me"
 msgstr ""
 

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -52,11 +52,11 @@ msgstr ""
 msgid "You are not allowed to edit this blog."
 msgstr ""
 
-# src/routes/blogs.rs:262
+# src/routes/blogs.rs:263
 msgid "You can't use this media as a blog icon."
 msgstr ""
 
-# src/routes/blogs.rs:280
+# src/routes/blogs.rs:281
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
@@ -64,31 +64,31 @@ msgstr ""
 msgid "To like a post, you need to be logged in"
 msgstr ""
 
-# src/routes/notifications.rs:29
+# src/routes/notifications.rs:30
 msgid "To see your notifications, you need to be logged in"
 msgstr ""
 
-# src/routes/posts.rs:93
+# src/routes/posts.rs:94
 msgid "This post isn't published yet."
 msgstr ""
 
-# src/routes/posts.rs:122
+# src/routes/posts.rs:123
 msgid "To write a new post, you need to be logged in"
 msgstr ""
 
-# src/routes/posts.rs:140
+# src/routes/posts.rs:141
 msgid "You are not an author of this blog."
 msgstr ""
 
-# src/routes/posts.rs:147
+# src/routes/posts.rs:148
 msgid "New post"
 msgstr ""
 
-# src/routes/posts.rs:192
+# src/routes/posts.rs:194
 msgid "Edit {0}"
 msgstr ""
 
-# src/routes/posts.rs:630
+# src/routes/posts.rs:636
 msgid "Couldn't obtain enough information about your account. Please make sure your username is correct."
 msgstr ""
 
@@ -96,31 +96,31 @@ msgstr ""
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
 
-# src/routes/session.rs:181
+# src/routes/session.rs:182
 msgid "Password reset"
 msgstr ""
 
-# src/routes/session.rs:182
+# src/routes/session.rs:183
 msgid "Here is the link to reset your password: {0}"
 msgstr ""
 
-# src/routes/session.rs:259
+# src/routes/session.rs:263
 msgid "Your password was successfully reset."
 msgstr ""
 
-# src/routes/session.rs:263
+# src/routes/session.rs:267
 msgid "Sorry, but the link expired. Try again"
 msgstr ""
 
-# src/routes/user.rs:136
+# src/routes/user.rs:137
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:244
+# src/routes/user.rs:246
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
-# src/routes/user.rs:344
+# src/routes/user.rs:348
 msgid "To edit your profile, you need to be logged in"
 msgstr ""
 
@@ -256,10 +256,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/pt.po
+++ b/po/plume/pt.po
@@ -266,10 +266,10 @@ msgid "Follow {}"
 msgstr "Seguir"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Entrar para gostar"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/pt.po
+++ b/po/plume/pt.po
@@ -48,6 +48,15 @@ msgstr "Para criar um novo blog, você precisa estar logado"
 msgid "A blog with the same name already exists."
 msgstr "Um blog com o mesmo nome já existe."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "A sua palavra-passe foi redefinida com sucesso."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Não está autorizado a apagar este blog."
@@ -64,9 +73,55 @@ msgstr "Você não pode usar esta mídia como um ícone do blog."
 msgid "You can't use this media as a blog banner."
 msgstr "Você não pode usar esta mídia como um banner do blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Você ainda não tem nenhuma mídia."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Você ainda não tem nenhuma mídia."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Para curtir uma postagem, você precisa estar logado"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Não está autorizado a apagar este blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Você não está autorizado a apagar este blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Novo artigo"
 msgid "Edit {0}"
 msgstr "Mudar {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Você não está autorizado a apagar este blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Você ainda não tem nenhuma mídia."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Não está autorizado a apagar este blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +186,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Para recompartilhar uma postagem, você precisa estar logado"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Você não está autorizado."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Você não está autorizado."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,6 +215,14 @@ msgstr "Desculpe, mas a ligação expirou. Tente novamente"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Para acessar seu painel, você precisa estar logado"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Para se inscrever em alguém, você precisa estar logado"
@@ -131,6 +230,27 @@ msgstr "Para se inscrever em alguém, você precisa estar logado"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Para editar seu perfil, você precisa estar logado"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Você ainda não tem nenhuma mídia."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/ro.po
+++ b/po/plume/ro.po
@@ -263,10 +263,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/ro.po
+++ b/po/plume/ro.po
@@ -49,6 +49,15 @@ msgstr "Pentru a crea un nou blog, trebuie sa fii logat"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Parola dumneavoastră a fost resetată cu succes."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Nu aveți permisiunea de a șterge acest blog."
@@ -65,9 +74,55 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Nu aveți permisiunea de a șterge acest blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Nu aveți permisiunea de a șterge acest blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -93,6 +148,34 @@ msgstr "Postare nouă"
 msgid "Edit {0}"
 msgstr "Editare {0}"
 
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Nu aveți permisiunea de a șterge acest blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Nu aveți permisiunea de a șterge acest blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -102,6 +185,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Pentru a redistribui un post, trebuie să fii logat"
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
+msgstr ""
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -123,12 +214,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/ru.po
+++ b/po/plume/ru.po
@@ -50,6 +50,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -66,9 +74,53 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/medias.rs:145
+msgid "You are not allowed to delete this media."
+msgstr ""
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Вы не авторизованы."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -94,6 +146,32 @@ msgstr "Новый пост"
 msgid "Edit {0}"
 msgstr ""
 
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Вы не авторизованы."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:565
+msgid "You are not allowed to delete this article."
+msgstr ""
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +181,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr ""
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Вы не авторизованы."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Вы не авторизованы."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,12 +210,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/ru.po
+++ b/po/plume/ru.po
@@ -266,10 +266,10 @@ msgid "Follow {}"
 msgstr "Подписаться"
 
 #, fuzzy
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr "Войдите, чтобы продвигать посты"
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/sk.po
+++ b/po/plume/sk.po
@@ -264,10 +264,12 @@ msgstr "Beží na Plume {0}"
 msgid "Follow {}"
 msgstr "Následuj {}"
 
-msgid "Login to follow"
+#, fuzzy
+msgid "Log in to follow"
 msgstr "Pre následovanie sa prihlás"
 
-msgid "Enter your full username to follow"
+#, fuzzy
+msgid "Enter your full username handle to follow"
 msgstr "Zadaj svoju prezývku v úplnosti, aby si následoval/a"
 
 msgid "Edit your account"

--- a/po/plume/sk.po
+++ b/po/plume/sk.po
@@ -48,6 +48,15 @@ msgstr "Aby si vytvoril/a nový blog, musíš sa prihlásiť"
 msgid "A blog with the same name already exists."
 msgstr "Blog s rovnakým názvom už existuje."
 
+# src/routes/session.rs:259
+#, fuzzy
+msgid "Your blog was successfully created!"
+msgstr "Tvoje heslo bolo úspešne zmenené."
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Nemáš povolenie vymazať tento blog."
@@ -64,9 +73,55 @@ msgstr "Tento mediálny súbor nemožno použiť ako ikonku pre blog."
 msgid "You can't use this media as a blog banner."
 msgstr "Tento mediálny súbor nemožno použiť ako záhlavie pre blog."
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your comment have been posted."
+msgstr "Ešte nemáš nahrané žiadne multimédiá."
+
+#, fuzzy
+msgid "Your comment have been deleted."
+msgstr "Ešte nemáš nahrané žiadne multimédiá."
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr "Aby si si obľúbil/a príspevok, musíš sa prihlásiť"
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Nemáš povolenie vymazať tento blog."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Nemáš dovolené upravovať tento blog."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +147,34 @@ msgstr "Nový príspevok"
 msgid "Edit {0}"
 msgstr "Uprav {0}"
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Nemáš dovolené upravovať tento blog."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your post have been saved."
+msgstr "Ešte nemáš nahrané žiadne multimédiá."
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Nemáš povolenie vymazať tento blog."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -103,6 +186,14 @@ msgstr ""
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
 msgstr "Na zdieľanie príspevku sa musíš prihlásiť"
+
+#, fuzzy
+msgid "You are now connected."
+msgstr "Nemáš oprávnenie."
+
+#, fuzzy
+msgid "You are now logged off."
+msgstr "Nemáš oprávnenie."
 
 # src/routes/session.rs:181
 msgid "Password reset"
@@ -124,6 +215,14 @@ msgstr "Prepáč, ale tento odkaz už vypŕšal. Skús to znova"
 msgid "To access your dashboard, you need to be logged in"
 msgstr "Pre prístup k prehľadovému panelu sa musíš prihlásiť"
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr "Ak chceš niekoho odoberať, musíš sa prihlásiť"
@@ -131,6 +230,27 @@ msgstr "Ak chceš niekoho odoberať, musíš sa prihlásiť"
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
 msgstr "Na upravenie tvojho profilu sa musíš prihlásiť"
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+#, fuzzy
+msgid "Your account have been deleted."
+msgstr "Ešte nemáš nahrané žiadne multimédiá."
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
+msgstr ""
 
 msgid "Plume"
 msgstr "Plume"

--- a/po/plume/sr.po
+++ b/po/plume/sr.po
@@ -263,10 +263,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/po/plume/sr.po
+++ b/po/plume/sr.po
@@ -49,6 +49,14 @@ msgstr ""
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr ""
@@ -65,8 +73,52 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
+msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/medias.rs:145
+msgid "You are not allowed to delete this media."
+msgstr ""
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/medias.rs:156
+msgid "You are not allowed to use this media."
 msgstr ""
 
 # src/routes/notifications.rs:29
@@ -93,6 +145,32 @@ msgstr ""
 msgid "Edit {0}"
 msgstr "Uredi {0}"
 
+# src/routes/posts.rs:264
+msgid "You are not allowed to publish on this blog."
+msgstr ""
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/posts.rs:565
+msgid "You are not allowed to delete this article."
+msgstr ""
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -101,6 +179,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -123,12 +209,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/sv.po
+++ b/po/plume/sv.po
@@ -48,6 +48,14 @@ msgstr "För att skapa en ny blogg måste du vara inloggad"
 msgid "A blog with the same name already exists."
 msgstr ""
 
+# src/routes/blogs.rs:142
+msgid "Your blog was successfully created!"
+msgstr ""
+
+# src/routes/blogs.rs:167
+msgid "Your blog was deleted."
+msgstr ""
+
 # src/routes/blogs.rs:172
 msgid "You are not allowed to delete this blog."
 msgstr "Du har inte tillstånd att ta bort den här bloggen."
@@ -64,9 +72,55 @@ msgstr ""
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
+# src/routes/blogs.rs:312
+msgid "Your blog information have been updated."
+msgstr ""
+
+# src/routes/comments.rs:89
+msgid "Your comment have been posted."
+msgstr ""
+
+# src/routes/comments.rs:163
+msgid "Your comment have been deleted."
+msgstr ""
+
+# src/routes/instance.rs:145
+msgid "Instance settings have been saved."
+msgstr ""
+
+# src/routes/instance.rs:182
+msgid "{} have been unblocked."
+msgstr ""
+
+# src/routes/instance.rs:184
+msgid "{} have been blocked."
+msgstr ""
+
+# src/routes/instance.rs:218
+msgid "{} have been banned."
+msgstr ""
+
 # src/routes/likes.rs:51
 msgid "To like a post, you need to be logged in"
 msgstr ""
+
+# src/routes/medias.rs:143
+msgid "Your media have been deleted."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this media."
+msgstr "Du har inte tillstånd att ta bort den här bloggen."
+
+# src/routes/medias.rs:154
+msgid "Your avatar have been updated."
+msgstr ""
+
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to use this media."
+msgstr "Du har inte tillstånd att redigera den här bloggen."
 
 # src/routes/notifications.rs:29
 msgid "To see your notifications, you need to be logged in"
@@ -92,6 +146,34 @@ msgstr ""
 msgid "Edit {0}"
 msgstr ""
 
+# src/routes/blogs.rs:217
+#, fuzzy
+msgid "You are not allowed to publish on this blog."
+msgstr "Du har inte tillstånd att redigera den här bloggen."
+
+# src/routes/posts.rs:351
+msgid "Your article have been updated."
+msgstr ""
+
+# src/routes/posts.rs:527
+msgid "Your post have been saved."
+msgstr ""
+
+# src/routes/blogs.rs:172
+#, fuzzy
+msgid "You are not allowed to delete this article."
+msgstr "Du har inte tillstånd att ta bort den här bloggen."
+
+# src/routes/posts.rs:589
+msgid "Your article have been deleted."
+msgstr ""
+
+# src/routes/posts.rs:593
+msgid ""
+"It looks like the article you tried to delete doesn't exist. Maybe it is "
+"already gone?"
+msgstr ""
+
 # src/routes/posts.rs:630
 msgid ""
 "Couldn't obtain enough information about your account. Please make sure your "
@@ -100,6 +182,14 @@ msgstr ""
 
 # src/routes/reshares.rs:51
 msgid "To reshare a post, you need to be logged in"
+msgstr ""
+
+# src/routes/session.rs:108
+msgid "You are now connected."
+msgstr ""
+
+# src/routes/session.rs:124
+msgid "You are now logged off."
 msgstr ""
 
 # src/routes/session.rs:181
@@ -122,12 +212,41 @@ msgstr ""
 msgid "To access your dashboard, you need to be logged in"
 msgstr ""
 
+# src/routes/user.rs:158
+msgid "You are no longer following {}."
+msgstr ""
+
+# src/routes/user.rs:174
+msgid "You are now following {}."
+msgstr ""
+
 # src/routes/user.rs:244
 msgid "To subscribe to someone, you need to be logged in"
 msgstr ""
 
 # src/routes/user.rs:344
 msgid "To edit your profile, you need to be logged in"
+msgstr ""
+
+# src/routes/user.rs:390
+msgid "Your profile have been updated."
+msgstr ""
+
+# src/routes/user.rs:409
+msgid "Your account have been deleted."
+msgstr ""
+
+# src/routes/user.rs:411
+msgid "You can't delete someone else's account."
+msgstr ""
+
+# src/routes/user.rs:473
+msgid "Registrations are closed on this instance."
+msgstr ""
+
+# src/routes/user.rs:491
+msgid ""
+"Your account have been created. You just need to login before you can use it."
 msgstr ""
 
 msgid "Plume"

--- a/po/plume/sv.po
+++ b/po/plume/sv.po
@@ -262,10 +262,10 @@ msgstr ""
 msgid "Follow {}"
 msgstr ""
 
-msgid "Login to follow"
+msgid "Log in to follow"
 msgstr ""
 
-msgid "Enter your full username to follow"
+msgid "Enter your full username handle to follow"
 msgstr ""
 
 msgid "Edit your account"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,6 @@ use plume_models::{
     search::{Searcher as UnmanagedSearcher, SearcherError},
     Connection, Error, CONFIG,
 };
-use rocket::State;
 use rocket_csrf::CsrfFairingBuilder;
 use scheduled_thread_pool::ScheduledThreadPool;
 use std::process::exit;
@@ -68,8 +67,6 @@ mod test_routes;
 include!(concat!(env!("OUT_DIR"), "/templates.rs"));
 
 compile_i18n!();
-
-type Searcher<'a> = State<'a, Arc<UnmanagedSearcher>>;
 
 /// Initializes a database pool.
 fn init_pool() -> Option<DbPool> {
@@ -102,8 +99,8 @@ Then try to restart Plume.
             SearcherError::IndexOpeningError => panic!(
                 r#"
 Plume was unable to open the search index. If you created the index
-before, make sure to run Plume in the same directory it was created in, or 
-to set SEARCH_INDEX accordingly. If you did not yet create the search 
+before, make sure to run Plume in the same directory it was created in, or
+to set SEARCH_INDEX accordingly. If you did not yet create the search
 index, run this command:
 
     plm search init

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -20,7 +20,12 @@ use routes::{errors::ErrorPage, Page};
 use template_utils::Ructe;
 
 #[get("/~/<name>?<page>", rank = 2)]
-pub fn details(name: String, page: Option<Page>, rockets: PlumeRocket, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn details(
+    name: String,
+    page: Option<Page>,
+    rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     let conn = &*rockets.conn;
     let blog = Blog::find_by_fqn(&rockets, &name)?;
@@ -90,7 +95,11 @@ fn valid_slug(title: &str) -> Result<(), ValidationError> {
 }
 
 #[post("/blogs/new", data = "<form>")]
-pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket, msg: Option<FlashMessage>) -> Result<Flash<Redirect>, Ructe> {
+pub fn create(
+    form: LenientForm<NewBlogForm>,
+    rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
+) -> Result<Flash<Redirect>, Ructe> {
     let slug = utils::make_actor_id(&form.title);
     let conn = &*rockets.conn;
     let intl = &rockets.intl.catalog;
@@ -139,7 +148,10 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket, msg: Option<
         )
         .expect("blog::create: author error");
 
-        Ok(Flash::success(Redirect::to(uri!(details: name = slug.clone(), page = _)), &i18n!(intl, "Your blog was successfully created!")))
+        Ok(Flash::success(
+            Redirect::to(uri!(details: name = slug.clone(), page = _)),
+            &i18n!(intl, "Your blog was successfully created!"),
+        ))
     } else {
         Err(render!(blogs::new(
             &(&*conn, intl, Some(user), msg),
@@ -150,7 +162,11 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket, msg: Option<
 }
 
 #[post("/~/<name>/delete")]
-pub fn delete(name: String, rockets: PlumeRocket, msg: Option<FlashMessage>) -> Result<Flash<Redirect>, Ructe> {
+pub fn delete(
+    name: String,
+    rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
+) -> Result<Flash<Redirect>, Ructe> {
     let conn = &*rockets.conn;
     let blog = Blog::find_by_fqn(&rockets, &name).expect("blog::delete: blog not found");
     let user = rockets.user;
@@ -164,7 +180,10 @@ pub fn delete(name: String, rockets: PlumeRocket, msg: Option<FlashMessage>) -> 
     {
         blog.delete(&conn, &searcher)
             .expect("blog::expect: deletion error");
-        Ok(Flash::success(Redirect::to(uri!(super::instance::index)), i18n!(intl.catalog, "Your blog was deleted.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(super::instance::index)),
+            i18n!(intl.catalog, "Your blog was deleted."),
+        ))
     } else {
         // TODO actually return 403 error code
         Err(render!(errors::not_authorized(
@@ -184,7 +203,11 @@ pub struct EditForm {
 }
 
 #[get("/~/<name>/edit")]
-pub fn edit(name: String, rockets: PlumeRocket, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn edit(
+    name: String,
+    rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let conn = &*rockets.conn;
     let blog = Blog::find_by_fqn(&rockets, &name)?;
     if rockets
@@ -309,7 +332,10 @@ pub fn update(
                 blog.banner_id = form.banner;
                 blog.save_changes::<Blog>(&*conn)
                     .expect("Couldn't save blog changes");
-                Ok(Flash::success(Redirect::to(uri!(details: name = name, page = _)), i18n!(intl, "Your blog information have been updated.")))
+                Ok(Flash::success(
+                    Redirect::to(uri!(details: name = name, page = _)),
+                    i18n!(intl, "Your blog information have been updated."),
+                ))
             })
             .map_err(|err| {
                 let medias = Media::for_user(&*conn, user.id).expect("Couldn't list media");

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -1,6 +1,6 @@
 use activitypub::object::Note;
 use rocket::{
-    request::{FlashMessage, LenientForm},
+    request::LenientForm,
     response::{Flash, Redirect},
 };
 use template_utils::Ructe;
@@ -17,6 +17,7 @@ use plume_models::{
     posts::Post, safe_string::SafeString, tags::Tag, users::User, Error, PlumeRocket,
 };
 use routes::errors::ErrorPage;
+use template_utils::IntoContext;
 
 #[derive(Default, FromForm, Debug, Validate)]
 pub struct NewCommentForm {
@@ -33,7 +34,6 @@ pub fn create(
     form: LenientForm<NewCommentForm>,
     user: User,
     rockets: PlumeRocket,
-    msg: Option<FlashMessage>,
 ) -> Result<Flash<Redirect>, Ructe> {
     let conn = &*rockets.conn;
     let blog = Blog::find_by_fqn(&rockets, &blog_name).expect("comments::create: blog error");
@@ -104,7 +104,7 @@ pub fn create(
                 .and_then(|r| Comment::get(&*conn, r).ok());
 
             render!(posts::details(
-                &(&*conn, &rockets.intl.catalog, Some(user.clone()), msg),
+                &rockets.to_context(),
                 post.clone(),
                 blog,
                 &*form,

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -1,5 +1,8 @@
 use activitypub::object::Note;
-use rocket::{request::{FlashMessage, LenientForm}, response::{Flash, Redirect}};
+use rocket::{
+    request::{FlashMessage, LenientForm},
+    response::{Flash, Redirect},
+};
 use template_utils::Ructe;
 use validator::Validate;
 
@@ -84,9 +87,12 @@ pub fn create(
                 .worker
                 .execute(move || broadcast(&user_clone, new_comment, dest));
 
-            Flash::success(Redirect::to(
-                uri!(super::posts::details: blog = blog_name, slug = slug, responding_to = _),
-            ), i18n!(&rockets.intl.catalog, "Your comment have been posted."))
+            Flash::success(
+                Redirect::to(
+                    uri!(super::posts::details: blog = blog_name, slug = slug, responding_to = _),
+                ),
+                i18n!(&rockets.intl.catalog, "Your comment have been posted."),
+            )
         })
         .map_err(|errors| {
             // TODO: de-duplicate this code
@@ -158,9 +164,10 @@ pub fn delete(
                 });
         }
     }
-    Ok(Flash::success(Redirect::to(
-        uri!(super::posts::details: blog = blog, slug = slug, responding_to = _),
-    ), i18n!(&rockets.intl.catalog, "Your comment have been deleted.")))
+    Ok(Flash::success(
+        Redirect::to(uri!(super::posts::details: blog = blog, slug = slug, responding_to = _)),
+        i18n!(&rockets.intl.catalog, "Your comment have been deleted."),
+    ))
 }
 
 #[get("/~/<_blog>/<_slug>/comment/<id>")]

--- a/src/routes/comments.rs
+++ b/src/routes/comments.rs
@@ -1,5 +1,5 @@
 use activitypub::object::Note;
-use rocket::{request::LenientForm, response::Redirect};
+use rocket::{request::{FlashMessage, LenientForm}, response::Redirect};
 use template_utils::Ructe;
 use validator::Validate;
 
@@ -30,6 +30,7 @@ pub fn create(
     form: LenientForm<NewCommentForm>,
     user: User,
     rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
 ) -> Result<Redirect, Ructe> {
     let conn = &*rockets.conn;
     let blog = Blog::find_by_fqn(&rockets, &blog_name).expect("comments::create: blog error");
@@ -97,7 +98,7 @@ pub fn create(
                 .and_then(|r| Comment::get(&*conn, r).ok());
 
             render!(posts::details(
-                &(&*conn, &rockets.intl.catalog, Some(user.clone())),
+                &(&*conn, &rockets.intl.catalog, Some(user.clone()), msg),
                 post.clone(),
                 blog,
                 &*form,

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -1,6 +1,6 @@
-use rocket::request::FlashMessage;
 use plume_models::users::User;
 use plume_models::{db_conn::DbConn, Error};
+use rocket::request::FlashMessage;
 use rocket::{
     request::FromRequest,
     response::{self, Responder},

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -1,3 +1,4 @@
+use rocket::request::FlashMessage;
 use plume_models::users::User;
 use plume_models::{db_conn::DbConn, Error};
 use rocket::{
@@ -22,24 +23,28 @@ impl<'r> Responder<'r> for ErrorPage {
         let conn = req.guard::<DbConn>().succeeded();
         let intl = req.guard::<I18n>().succeeded();
         let user = User::from_request(req).succeeded();
+        let msg = req.guard::<FlashMessage>().succeeded();
 
         match self.0 {
             Error::NotFound => render!(errors::not_found(&(
                 &*conn.unwrap(),
                 &intl.unwrap().catalog,
-                user
+                user,
+                msg
             )))
             .respond_to(req),
             Error::Unauthorized => render!(errors::not_found(&(
                 &*conn.unwrap(),
                 &intl.unwrap().catalog,
-                user
+                user,
+                msg
             )))
             .respond_to(req),
             _ => render!(errors::not_found(&(
                 &*conn.unwrap(),
                 &intl.unwrap().catalog,
-                user
+                user,
+                msg
             )))
             .respond_to(req),
         }
@@ -51,10 +56,12 @@ pub fn not_found(req: &Request) -> Ructe {
     let conn = req.guard::<DbConn>().succeeded();
     let intl = req.guard::<I18n>().succeeded();
     let user = User::from_request(req).succeeded();
+    let msg = req.guard::<FlashMessage>().succeeded();
     render!(errors::not_found(&(
         &*conn.unwrap(),
         &intl.unwrap().catalog,
-        user
+        user,
+        msg
     )))
 }
 
@@ -63,10 +70,12 @@ pub fn unprocessable_entity(req: &Request) -> Ructe {
     let conn = req.guard::<DbConn>().succeeded();
     let intl = req.guard::<I18n>().succeeded();
     let user = User::from_request(req).succeeded();
+    let msg = req.guard::<FlashMessage>().succeeded();
     render!(errors::unprocessable_entity(&(
         &*conn.unwrap(),
         &intl.unwrap().catalog,
-        user
+        user,
+        msg
     )))
 }
 
@@ -75,10 +84,12 @@ pub fn server_error(req: &Request) -> Ructe {
     let conn = req.guard::<DbConn>().succeeded();
     let intl = req.guard::<I18n>().succeeded();
     let user = User::from_request(req).succeeded();
+    let msg = req.guard::<FlashMessage>().succeeded();
     render!(errors::server_error(&(
         &*conn.unwrap(),
         &intl.unwrap().catalog,
-        user
+        user,
+        msg
     )))
 }
 
@@ -88,9 +99,10 @@ pub fn csrf_violation(
     conn: DbConn,
     intl: I18n,
     user: Option<User>,
+    msg: Option<FlashMessage>,
 ) -> Ructe {
     if let Some(uri) = target {
         eprintln!("Csrf violation while acceding \"{}\"", uri)
     }
-    render!(errors::csrf(&(&*conn, &intl.catalog, user)))
+    render!(errors::csrf(&(&*conn, &intl.catalog, user, msg)))
 }

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -1,13 +1,9 @@
-use plume_models::users::User;
-use plume_models::{db_conn::DbConn, Error};
-use rocket::request::FlashMessage;
+use plume_models::{Error, PlumeRocket};
 use rocket::{
-    request::FromRequest,
     response::{self, Responder},
     Request,
 };
-use rocket_i18n::I18n;
-use template_utils::Ructe;
+use template_utils::{IntoContext, Ructe};
 
 #[derive(Debug)]
 pub struct ErrorPage(Error);
@@ -20,89 +16,40 @@ impl From<Error> for ErrorPage {
 
 impl<'r> Responder<'r> for ErrorPage {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
-        let conn = req.guard::<DbConn>().succeeded();
-        let intl = req.guard::<I18n>().succeeded();
-        let user = User::from_request(req).succeeded();
-        let msg = req.guard::<FlashMessage>().succeeded();
+        let rockets = req.guard::<PlumeRocket>().unwrap();
 
         match self.0 {
-            Error::NotFound => render!(errors::not_found(&(
-                &*conn.unwrap(),
-                &intl.unwrap().catalog,
-                user,
-                msg
-            )))
-            .respond_to(req),
-            Error::Unauthorized => render!(errors::not_found(&(
-                &*conn.unwrap(),
-                &intl.unwrap().catalog,
-                user,
-                msg
-            )))
-            .respond_to(req),
-            _ => render!(errors::not_found(&(
-                &*conn.unwrap(),
-                &intl.unwrap().catalog,
-                user,
-                msg
-            )))
-            .respond_to(req),
+            Error::NotFound => render!(errors::not_found(&rockets.to_context())).respond_to(req),
+            Error::Unauthorized => {
+                render!(errors::not_found(&rockets.to_context())).respond_to(req)
+            }
+            _ => render!(errors::not_found(&rockets.to_context())).respond_to(req),
         }
     }
 }
 
 #[catch(404)]
 pub fn not_found(req: &Request) -> Ructe {
-    let conn = req.guard::<DbConn>().succeeded();
-    let intl = req.guard::<I18n>().succeeded();
-    let user = User::from_request(req).succeeded();
-    let msg = req.guard::<FlashMessage>().succeeded();
-    render!(errors::not_found(&(
-        &*conn.unwrap(),
-        &intl.unwrap().catalog,
-        user,
-        msg
-    )))
+    let rockets = req.guard::<PlumeRocket>().unwrap();
+    render!(errors::not_found(&rockets.to_context()))
 }
 
 #[catch(422)]
 pub fn unprocessable_entity(req: &Request) -> Ructe {
-    let conn = req.guard::<DbConn>().succeeded();
-    let intl = req.guard::<I18n>().succeeded();
-    let user = User::from_request(req).succeeded();
-    let msg = req.guard::<FlashMessage>().succeeded();
-    render!(errors::unprocessable_entity(&(
-        &*conn.unwrap(),
-        &intl.unwrap().catalog,
-        user,
-        msg
-    )))
+    let rockets = req.guard::<PlumeRocket>().unwrap();
+    render!(errors::unprocessable_entity(&rockets.to_context()))
 }
 
 #[catch(500)]
 pub fn server_error(req: &Request) -> Ructe {
-    let conn = req.guard::<DbConn>().succeeded();
-    let intl = req.guard::<I18n>().succeeded();
-    let user = User::from_request(req).succeeded();
-    let msg = req.guard::<FlashMessage>().succeeded();
-    render!(errors::server_error(&(
-        &*conn.unwrap(),
-        &intl.unwrap().catalog,
-        user,
-        msg
-    )))
+    let rockets = req.guard::<PlumeRocket>().unwrap();
+    render!(errors::server_error(&rockets.to_context()))
 }
 
 #[post("/csrf-violation?<target>")]
-pub fn csrf_violation(
-    target: Option<String>,
-    conn: DbConn,
-    intl: I18n,
-    user: Option<User>,
-    msg: Option<FlashMessage>,
-) -> Ructe {
+pub fn csrf_violation(target: Option<String>, rockets: PlumeRocket) -> Ructe {
     if let Some(uri) = target {
         eprintln!("Csrf violation while acceding \"{}\"", uri)
     }
-    render!(errors::csrf(&(&*conn, &intl.catalog, user, msg)))
+    render!(errors::csrf(&rockets.to_context()))
 }

--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -18,7 +18,12 @@ use template_utils::Ructe;
 use Searcher;
 
 #[get("/")]
-pub fn index(conn: DbConn, user: Option<User>, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn index(
+    conn: DbConn,
+    user: Option<User>,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let inst = Instance::get_local(&*conn)?;
     let federated = Post::get_recents_page(&*conn, Page::default().limits())?;
     let local = Post::get_instance_page(&*conn, inst.id, Page::default().limits())?;
@@ -46,7 +51,7 @@ pub fn local(
     user: Option<User>,
     page: Option<Page>,
     intl: I18n,
-    msg: Option<FlashMessage>
+    msg: Option<FlashMessage>,
 ) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     let instance = Instance::get_local(&*conn)?;
@@ -61,7 +66,13 @@ pub fn local(
 }
 
 #[get("/feed?<page>")]
-pub fn feed(conn: DbConn, user: User, page: Option<Page>, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn feed(
+    conn: DbConn,
+    user: User,
+    page: Option<Page>,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     let followed = user.get_followed(&*conn)?;
     let mut in_feed = followed.into_iter().map(|u| u.id).collect::<Vec<i32>>();
@@ -94,7 +105,12 @@ pub fn federated(
 }
 
 #[get("/admin")]
-pub fn admin(conn: DbConn, admin: Admin, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn admin(
+    conn: DbConn,
+    admin: Admin,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let local_inst = Instance::get_local(&*conn)?;
     Ok(render!(instance::admin(
         &(&*conn, &intl.catalog, Some(admin.0), msg),
@@ -142,7 +158,10 @@ pub fn update_settings(
                     form.long_description.clone(),
                 )
                 .expect("instance::update_settings: save error");
-            Ok(Flash::success(Redirect::to(uri!(admin)), i18n!(&intl.catalog, "Instance settings have been saved.")))
+            Ok(Flash::success(
+                Redirect::to(uri!(admin)),
+                i18n!(&intl.catalog, "Instance settings have been saved."),
+            ))
         })
         .or_else(|e| {
             let local_inst = Instance::get_local(&*conn)
@@ -176,7 +195,12 @@ pub fn admin_instances(
 }
 
 #[post("/admin/instances/<id>/block")]
-pub fn toggle_block(_admin: Admin, conn: DbConn, id: i32, intl: I18n) -> Result<Flash<Redirect>, ErrorPage> {
+pub fn toggle_block(
+    _admin: Admin,
+    conn: DbConn,
+    id: i32,
+    intl: I18n,
+) -> Result<Flash<Redirect>, ErrorPage> {
     let inst = Instance::get(&*conn, id)?;
     let message = if inst.blocked {
         i18n!(intl.catalog, "{} have been unblocked."; &inst.name)
@@ -185,7 +209,10 @@ pub fn toggle_block(_admin: Admin, conn: DbConn, id: i32, intl: I18n) -> Result<
     };
 
     inst.toggle_block(&*conn)?;
-    Ok(Flash::success(Redirect::to(uri!(admin_instances: page = _)), message))
+    Ok(Flash::success(
+        Redirect::to(uri!(admin_instances: page = _)),
+        message,
+    ))
 }
 
 #[get("/admin/users?<page>")]
@@ -215,7 +242,10 @@ pub fn ban(
 ) -> Result<Flash<Redirect>, ErrorPage> {
     let u = User::get(&*conn, id)?;
     u.delete(&*conn, &searcher)?;
-    Ok(Flash::success(Redirect::to(uri!(admin_users: page = _)), i18n!(intl.catalog, "{} have been banned."; u.name())))
+    Ok(Flash::success(
+        Redirect::to(uri!(admin_users: page = _)),
+        i18n!(intl.catalog, "{} have been banned."; u.name()),
+    ))
 }
 
 #[post("/inbox", data = "<data>")]
@@ -297,7 +327,12 @@ pub fn nodeinfo(conn: DbConn, version: String) -> Result<Json<serde_json::Value>
 }
 
 #[get("/about")]
-pub fn about(user: Option<User>, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn about(
+    user: Option<User>,
+    conn: DbConn,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     Ok(render!(instance::about(
         &(&*conn, &intl.catalog, user, msg),
         Instance::get_local(&*conn)?,

--- a/src/routes/medias.rs
+++ b/src/routes/medias.rs
@@ -16,7 +16,13 @@ use std::fs;
 use template_utils::Ructe;
 
 #[get("/medias?<page>")]
-pub fn list(user: User, conn: DbConn, intl: I18n, page: Option<Page>, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn list(
+    user: User,
+    conn: DbConn,
+    intl: I18n,
+    page: Option<Page>,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     let medias = Media::page_for_user(&*conn, &user, page.limits())?;
     Ok(render!(medias::index(
@@ -123,7 +129,13 @@ fn read(data: &SavedData) -> Result<String, status::BadRequest<&'static str>> {
 }
 
 #[get("/medias/<id>")]
-pub fn details(id: i32, user: User, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn details(
+    id: i32,
+    user: User,
+    conn: DbConn,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let media = Media::get(&*conn, id)?;
     if media.owner_id == user.id {
         Ok(render!(medias::details(
@@ -140,19 +152,36 @@ pub fn delete(id: i32, user: User, conn: DbConn, intl: I18n) -> Result<Flash<Red
     let media = Media::get(&*conn, id)?;
     if media.owner_id == user.id {
         media.delete(&*conn)?;
-        Ok(Flash::success(Redirect::to(uri!(list: page = _)), i18n!(intl.catalog, "Your media have been deleted.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(list: page = _)),
+            i18n!(intl.catalog, "Your media have been deleted."),
+        ))
     } else {
-        Ok(Flash::error(Redirect::to(uri!(list: page = _)), i18n!(intl.catalog, "You are not allowed to delete this media.")))
+        Ok(Flash::error(
+            Redirect::to(uri!(list: page = _)),
+            i18n!(intl.catalog, "You are not allowed to delete this media."),
+        ))
     }
 }
 
 #[post("/medias/<id>/avatar")]
-pub fn set_avatar(id: i32, user: User, conn: DbConn, intl: I18n) -> Result<Flash<Redirect>, ErrorPage> {
+pub fn set_avatar(
+    id: i32,
+    user: User,
+    conn: DbConn,
+    intl: I18n,
+) -> Result<Flash<Redirect>, ErrorPage> {
     let media = Media::get(&*conn, id)?;
     if media.owner_id == user.id {
         user.set_avatar(&*conn, media.id)?;
-        Ok(Flash::success(Redirect::to(uri!(details: id = id)), i18n!(intl.catalog, "Your avatar have been updated.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(details: id = id)),
+            i18n!(intl.catalog, "Your avatar have been updated."),
+        ))
     } else {
-        Ok(Flash::error(Redirect::to(uri!(details: id = id)), i18n!(intl.catalog, "You are not allowed to use this media.")))
+        Ok(Flash::error(
+            Redirect::to(uri!(details: id = id)),
+            i18n!(intl.catalog, "You are not allowed to use this media."),
+        ))
     }
 }

--- a/src/routes/medias.rs
+++ b/src/routes/medias.rs
@@ -3,39 +3,32 @@ use multipart::server::{
     save::{SaveResult, SavedData},
     Multipart,
 };
-use plume_models::{db_conn::DbConn, medias::*, users::User, Error};
+use plume_models::{db_conn::DbConn, medias::*, users::User, Error, PlumeRocket};
 use rocket::{
     http::ContentType,
-    request::FlashMessage,
     response::{status, Flash, Redirect},
     Data,
 };
 use rocket_i18n::I18n;
 use routes::{errors::ErrorPage, Page};
 use std::fs;
-use template_utils::Ructe;
+use template_utils::{IntoContext, Ructe};
 
 #[get("/medias?<page>")]
-pub fn list(
-    user: User,
-    conn: DbConn,
-    intl: I18n,
-    page: Option<Page>,
-    msg: Option<FlashMessage>,
-) -> Result<Ructe, ErrorPage> {
+pub fn list(user: User, page: Option<Page>, rockets: PlumeRocket) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
-    let medias = Media::page_for_user(&*conn, &user, page.limits())?;
+    let medias = Media::page_for_user(&*rockets.conn, &user, page.limits())?;
     Ok(render!(medias::index(
-        &(&*conn, &intl.catalog, Some(user.clone()), msg),
+        &rockets.to_context(),
         medias,
         page.0,
-        Page::total(Media::count_for_user(&*conn, &user)? as i32)
+        Page::total(Media::count_for_user(&*rockets.conn, &user)? as i32)
     )))
 }
 
 #[get("/medias/new")]
-pub fn new(user: User, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Ructe {
-    render!(medias::new(&(&*conn, &intl.catalog, Some(user), msg)))
+pub fn new(_user: User, rockets: PlumeRocket) -> Ructe {
+    render!(medias::new(&rockets.to_context()))
 }
 
 #[post("/medias/new", data = "<data>")]
@@ -129,19 +122,10 @@ fn read(data: &SavedData) -> Result<String, status::BadRequest<&'static str>> {
 }
 
 #[get("/medias/<id>")]
-pub fn details(
-    id: i32,
-    user: User,
-    conn: DbConn,
-    intl: I18n,
-    msg: Option<FlashMessage>,
-) -> Result<Ructe, ErrorPage> {
-    let media = Media::get(&*conn, id)?;
+pub fn details(id: i32, user: User, rockets: PlumeRocket) -> Result<Ructe, ErrorPage> {
+    let media = Media::get(&*rockets.conn, id)?;
     if media.owner_id == user.id {
-        Ok(render!(medias::details(
-            &(&*conn, &intl.catalog, Some(user), msg),
-            media
-        )))
+        Ok(render!(medias::details(&rockets.to_context(), media)))
     } else {
         Err(Error::Unauthorized.into())
     }

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,4 +1,4 @@
-use rocket::response::{Flash, Redirect};
+use rocket::{request::FlashMessage, response::{Flash, Redirect}};
 use rocket_i18n::I18n;
 
 use plume_common::utils;
@@ -12,10 +12,11 @@ pub fn notifications(
     user: User,
     page: Option<Page>,
     intl: I18n,
+    msg: Option<FlashMessage>,
 ) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     Ok(render!(notifications::index(
-        &(&*conn, &intl.catalog, Some(user.clone())),
+        &(&*conn, &intl.catalog, Some(user.clone()), msg),
         Notification::page_for_user(&*conn, &user, page.limits())?,
         page.0,
         Page::total(Notification::count_for_user(&*conn, &user)? as i32)

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,28 +1,23 @@
-use rocket::{
-    request::FlashMessage,
-    response::{Flash, Redirect},
-};
+use rocket::response::{Flash, Redirect};
 use rocket_i18n::I18n;
 
 use plume_common::utils;
-use plume_models::{db_conn::DbConn, notifications::Notification, users::User};
+use plume_models::{notifications::Notification, users::User, PlumeRocket};
 use routes::{errors::ErrorPage, Page};
-use template_utils::Ructe;
+use template_utils::{IntoContext, Ructe};
 
 #[get("/notifications?<page>")]
 pub fn notifications(
-    conn: DbConn,
     user: User,
     page: Option<Page>,
-    intl: I18n,
-    msg: Option<FlashMessage>,
+    rockets: PlumeRocket,
 ) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     Ok(render!(notifications::index(
-        &(&*conn, &intl.catalog, Some(user.clone()), msg),
-        Notification::page_for_user(&*conn, &user, page.limits())?,
+        &rockets.to_context(),
+        Notification::page_for_user(&*rockets.conn, &user, page.limits())?,
         page.0,
-        Page::total(Notification::count_for_user(&*conn, &user)? as i32)
+        Page::total(Notification::count_for_user(&*rockets.conn, &user)? as i32)
     )))
 }
 

--- a/src/routes/notifications.rs
+++ b/src/routes/notifications.rs
@@ -1,4 +1,7 @@
-use rocket::{request::FlashMessage, response::{Flash, Redirect}};
+use rocket::{
+    request::FlashMessage,
+    response::{Flash, Redirect},
+};
 use rocket_i18n::I18n;
 
 use plume_common::utils;

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -128,7 +128,12 @@ pub fn new_auth(blog: String, i18n: I18n) -> Flash<Redirect> {
 }
 
 #[get("/~/<blog>/new", rank = 1)]
-pub fn new(blog: String, cl: ContentLen, rockets: PlumeRocket, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn new(
+    blog: String,
+    cl: ContentLen,
+    rockets: PlumeRocket,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let conn = &*rockets.conn;
     let b = Blog::find_by_fqn(&rockets, &blog)?;
     let user = rockets.user.unwrap();
@@ -259,9 +264,10 @@ pub fn update(
             .expect("posts::update: is author in error")
         {
             // actually it's not "Ok"…
-            Ok(Flash::error(Redirect::to(
-                uri!(super::blogs::details: name = blog, page = _),
-            ), i18n!(&intl, "You are not allowed to publish on this blog.")))
+            Ok(Flash::error(
+                Redirect::to(uri!(super::blogs::details: name = blog, page = _)),
+                i18n!(&intl, "You are not allowed to publish on this blog."),
+            ))
         } else {
             let (content, mentions, hashtags) = utils::md_to_html(
                 form.content.to_string().as_ref(),
@@ -346,9 +352,10 @@ pub fn update(
                 }
             }
 
-            Ok(Flash::success(Redirect::to(
-                uri!(details: blog = blog, slug = new_slug, responding_to = _),
-            ), i18n!(intl, "Your article have been updated.")))
+            Ok(Flash::success(
+                Redirect::to(uri!(details: blog = blog, slug = new_slug, responding_to = _)),
+                i18n!(intl, "Your article have been updated."),
+            ))
         }
     } else {
         let medias = Media::for_user(&*conn, user.id).expect("posts:update: medias error");
@@ -424,9 +431,13 @@ pub fn create(
             .expect("post::create: is author in error")
         {
             // actually it's not "Ok"…
-            return Ok(Flash::error(Redirect::to(
-                uri!(super::blogs::details: name = blog_name, page = _),
-            ), i18n!(&rockets.intl.catalog, "You are not allowed to publish on this blog.")));
+            return Ok(Flash::error(
+                Redirect::to(uri!(super::blogs::details: name = blog_name, page = _)),
+                i18n!(
+                    &rockets.intl.catalog,
+                    "You are not allowed to publish on this blog."
+                ),
+            ));
         }
 
         let (content, mentions, hashtags) = utils::md_to_html(
@@ -522,9 +533,10 @@ pub fn create(
             worker.execute(move || broadcast(&user, act, dest));
         }
 
-        Ok(Flash::success(Redirect::to(
-            uri!(details: blog = blog_name, slug = slug, responding_to = _),
-        ), i18n!(&rockets.intl.catalog, "Your post have been saved.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(details: blog = blog_name, slug = slug, responding_to = _)),
+            i18n!(&rockets.intl.catalog, "Your post have been saved."),
+        ))
     } else {
         let medias = Media::for_user(&*conn, user.id).expect("posts::create: medias error");
         let intl = rockets.intl;
@@ -560,9 +572,12 @@ pub fn delete(
             .into_iter()
             .any(|a| a.id == user.id)
         {
-            return Ok(Flash::error(Redirect::to(
-                uri!(details: blog = blog_name.clone(), slug = slug.clone(), responding_to = _),
-            ), i18n!(intl.catalog, "You are not allowed to delete this article.")));
+            return Ok(Flash::error(
+                Redirect::to(
+                    uri!(details: blog = blog_name.clone(), slug = slug.clone(), responding_to = _),
+                ),
+                i18n!(intl.catalog, "You are not allowed to delete this article."),
+            ));
         }
 
         let dest = User::one_by_instance(&*rockets.conn)?;
@@ -584,9 +599,10 @@ pub fn delete(
                     .expect("Failed to rotate keypair");
             });
 
-        Ok(Flash::success(Redirect::to(
-            uri!(super::blogs::details: name = blog_name, page = _),
-        ), i18n!(intl.catalog, "Your article have been deleted.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(super::blogs::details: name = blog_name, page = _)),
+            i18n!(intl.catalog, "Your article have been deleted."),
+        ))
     } else {
         Ok(Flash::error(Redirect::to(
             uri!(super::blogs::details: name = blog_name, page = _),

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -1,5 +1,5 @@
 use chrono::offset::Utc;
-use rocket::request::Form;
+use rocket::request::{FlashMessage, Form};
 use rocket_i18n::I18n;
 
 use plume_models::{db_conn::DbConn, search::Query, users::User};
@@ -58,6 +58,7 @@ pub fn search(
     searcher: Searcher,
     user: Option<User>,
     intl: I18n,
+    msg: Option<FlashMessage>,
 ) -> Ructe {
     let query = query.map(Form::into_inner).unwrap_or_default();
     let page = query.page.unwrap_or_default();
@@ -73,14 +74,14 @@ pub fn search(
 
     if str_query.is_empty() {
         render!(search::index(
-            &(&*conn, &intl.catalog, user),
+            &(&*conn, &intl.catalog, user, msg),
             &format!("{}", Utc::today().format("%Y-%m-d"))
         ))
     } else {
         let res = searcher.search_document(&conn, parsed_query, page.limits());
         let next_page = if res.is_empty() { 0 } else { page.0 + 1 };
         render!(search::result(
-            &(&*conn, &intl.catalog, user),
+            &(&*conn, &intl.catalog, user, msg),
             &str_query,
             res,
             page.0,

--- a/src/routes/session.rs
+++ b/src/routes/session.rs
@@ -24,7 +24,13 @@ use plume_models::{
 use routes::errors::ErrorPage;
 
 #[get("/login?<m>")]
-pub fn new(user: Option<User>, conn: DbConn, m: Option<String>, intl: I18n, msg: Option<FlashMessage>) -> Ructe {
+pub fn new(
+    user: Option<User>,
+    conn: DbConn,
+    m: Option<String>,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Ructe {
     render!(session::login(
         &(&*conn, &intl.catalog, user, msg),
         m,
@@ -105,7 +111,10 @@ pub fn create(
                 ))
             })?;
 
-        Ok(Flash::success(Redirect::to(uri), i18n!(&rockets.intl.catalog, "You are now connected.")))
+        Ok(Flash::success(
+            Redirect::to(uri),
+            i18n!(&rockets.intl.catalog, "You are now connected."),
+        ))
     } else {
         Err(render!(session::login(
             &(&*conn, &rockets.intl.catalog, None, flash),
@@ -121,7 +130,10 @@ pub fn delete(mut cookies: Cookies, intl: I18n) -> Flash<Redirect> {
     if let Some(cookie) = cookies.get_private(AUTH_COOKIE) {
         cookies.remove_private(cookie);
     }
-    Flash::success(Redirect::to("/"), i18n!(intl.catalog, "You are now logged off."))
+    Flash::success(
+        Redirect::to("/"),
+        i18n!(intl.catalog, "You are now logged off."),
+    )
 }
 
 #[derive(Clone)]

--- a/src/routes/session.rs
+++ b/src/routes/session.rs
@@ -2,7 +2,7 @@ use lettre::Transport;
 use rocket::http::ext::IntoOwned;
 use rocket::{
     http::{uri::Uri, Cookie, Cookies, SameSite},
-    request::{FlashMessage, Form, LenientForm},
+    request::{Form, LenientForm},
     response::{Flash, Redirect},
     State,
 };
@@ -12,27 +12,20 @@ use std::{
     sync::{Arc, Mutex},
     time::Instant,
 };
-use template_utils::Ructe;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use mail::{build_mail, Mailer};
 use plume_models::{
-    db_conn::DbConn,
     users::{User, AUTH_COOKIE},
     Error, PlumeRocket, CONFIG,
 };
 use routes::errors::ErrorPage;
+use template_utils::{IntoContext, Ructe};
 
 #[get("/login?<m>")]
-pub fn new(
-    user: Option<User>,
-    conn: DbConn,
-    m: Option<String>,
-    intl: I18n,
-    msg: Option<FlashMessage>,
-) -> Ructe {
+pub fn new(m: Option<String>, rockets: PlumeRocket) -> Ructe {
     render!(session::login(
-        &(&*conn, &intl.catalog, user, msg),
+        &rockets.to_context(),
         m,
         &LoginForm::default(),
         ValidationErrors::default()
@@ -50,7 +43,6 @@ pub struct LoginForm {
 #[post("/login", data = "<form>")]
 pub fn create(
     form: LenientForm<LoginForm>,
-    flash: Option<FlashMessage>,
     mut cookies: Cookies,
     rockets: PlumeRocket,
 ) -> Result<Flash<Redirect>, Ructe> {
@@ -90,21 +82,25 @@ pub fn create(
                 .same_site(SameSite::Lax)
                 .finish(),
         );
-        let destination = flash
-            .and_then(|f| {
-                if f.name() == "callback" {
-                    Some(f.msg().to_owned())
-                } else {
-                    None
-                }
-            })
+        let destination = rockets
+            .flash_msg
+            .clone()
+            .and_then(
+                |(name, msg)| {
+                    if name == "callback" {
+                        Some(msg)
+                    } else {
+                        None
+                    }
+                },
+            )
             .unwrap_or_else(|| "/".to_owned());
 
         let uri = Uri::parse(&destination)
             .map(IntoOwned::into_owned)
             .map_err(|_| {
                 render!(session::login(
-                    &(&*conn, &rockets.intl.catalog, None, None),
+                    &(conn, &rockets.intl.catalog, None, None),
                     None,
                     &*form,
                     errors
@@ -117,7 +113,7 @@ pub fn create(
         ))
     } else {
         Err(render!(session::login(
-            &(&*conn, &rockets.intl.catalog, None, flash),
+            &rockets.to_context(),
             None,
             &*form,
             errors
@@ -150,9 +146,9 @@ impl PartialEq for ResetRequest {
 }
 
 #[get("/password-reset")]
-pub fn password_reset_request_form(conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Ructe {
+pub fn password_reset_request_form(rockets: PlumeRocket) -> Ructe {
     render!(session::password_reset_request(
-        &(&*conn, &intl.catalog, None, msg),
+        &rockets.to_context(),
         &ResetForm::default(),
         ValidationErrors::default()
     ))
@@ -166,18 +162,16 @@ pub struct ResetForm {
 
 #[post("/password-reset", data = "<form>")]
 pub fn password_reset_request(
-    conn: DbConn,
-    intl: I18n,
     mail: State<Arc<Mutex<Mailer>>>,
     form: Form<ResetForm>,
     requests: State<Arc<Mutex<Vec<ResetRequest>>>>,
-    msg: Option<FlashMessage>,
+    rockets: PlumeRocket,
 ) -> Ructe {
     let mut requests = requests.lock().unwrap();
     // Remove outdated requests (more than 1 day old) to avoid the list to grow too much
     requests.retain(|r| r.creation_date.elapsed().as_secs() < 24 * 60 * 60);
 
-    if User::find_by_email(&*conn, &form.email).is_ok()
+    if User::find_by_email(&*rockets.conn, &form.email).is_ok()
         && !requests.iter().any(|x| x.mail == form.email.clone())
     {
         let id = plume_common::utils::random_hex();
@@ -191,8 +185,8 @@ pub fn password_reset_request(
         let link = format!("https://{}/password-reset/{}", CONFIG.base_url, id);
         if let Some(message) = build_mail(
             form.email.clone(),
-            i18n!(intl.catalog, "Password reset"),
-            i18n!(intl.catalog, "Here is the link to reset your password: {0}"; link),
+            i18n!(rockets.intl.catalog, "Password reset"),
+            i18n!(rockets.intl.catalog, "Here is the link to reset your password: {0}"; link),
         ) {
             if let Some(ref mut mail) = *mail.lock().unwrap() {
                 mail.send(message.into())
@@ -201,21 +195,14 @@ pub fn password_reset_request(
             }
         }
     }
-    render!(session::password_reset_request_ok(&(
-        &*conn,
-        &intl.catalog,
-        None,
-        msg
-    )))
+    render!(session::password_reset_request_ok(&rockets.to_context()))
 }
 
 #[get("/password-reset/<token>")]
 pub fn password_reset_form(
-    conn: DbConn,
-    intl: I18n,
     token: String,
     requests: State<Arc<Mutex<Vec<ResetRequest>>>>,
-    msg: Option<FlashMessage>,
+    rockets: PlumeRocket,
 ) -> Result<Ructe, ErrorPage> {
     requests
         .lock()
@@ -224,7 +211,7 @@ pub fn password_reset_form(
         .find(|x| x.id == token.clone())
         .ok_or(Error::NotFound)?;
     Ok(render!(session::password_reset(
-        &(&*conn, &intl.catalog, None, msg),
+        &rockets.to_context(),
         &NewPasswordForm::default(),
         ValidationErrors::default()
     )))
@@ -251,13 +238,11 @@ fn passwords_match(form: &NewPasswordForm) -> Result<(), ValidationError> {
 
 #[post("/password-reset/<token>", data = "<form>")]
 pub fn password_reset(
-    conn: DbConn,
-    intl: I18n,
     token: String,
     requests: State<Arc<Mutex<Vec<ResetRequest>>>>,
     form: Form<NewPasswordForm>,
-    msg: Option<FlashMessage>,
-) -> Result<Redirect, Ructe> {
+    rockets: PlumeRocket,
+) -> Result<Flash<Redirect>, Ructe> {
     form.validate()
         .and_then(|_| {
             let mut requests = requests.lock().unwrap();
@@ -269,24 +254,30 @@ pub fn password_reset(
             if req.creation_date.elapsed().as_secs() < 60 * 60 * 2 {
                 // Reset link is only valid for 2 hours
                 requests.retain(|r| *r != req);
-                let user = User::find_by_email(&*conn, &req.mail).map_err(to_validation)?;
-                user.reset_password(&*conn, &form.password).ok();
-                Ok(Redirect::to(uri!(
-                    new: m = i18n!(intl.catalog, "Your password was successfully reset.")
-                )))
+                let user = User::find_by_email(&*rockets.conn, &req.mail).map_err(to_validation)?;
+                user.reset_password(&*rockets.conn, &form.password).ok();
+                Ok(Flash::success(
+                    Redirect::to(uri!(
+                        new: m = _
+                    )),
+                    i18n!(
+                        rockets.intl.catalog,
+                        "Your password was successfully reset."
+                    ),
+                ))
             } else {
-                Ok(Redirect::to(uri!(
-                    new: m = i18n!(intl.catalog, "Sorry, but the link expired. Try again")
-                )))
+                Ok(Flash::error(
+                    Redirect::to(uri!(
+                        new: m = _
+                    )),
+                    i18n!(
+                        rockets.intl.catalog,
+                        "Sorry, but the link expired. Try again"
+                    ),
+                ))
             }
         })
-        .map_err(|err| {
-            render!(session::password_reset(
-                &(&*conn, &intl.catalog, None, msg),
-                &form,
-                err
-            ))
-        })
+        .map_err(|err| render!(session::password_reset(&rockets.to_context(), &form, err)))
 }
 
 fn to_validation<T>(_: T) -> ValidationErrors {

--- a/src/routes/tags.rs
+++ b/src/routes/tags.rs
@@ -1,3 +1,4 @@
+use rocket::request::FlashMessage;
 use rocket_i18n::I18n;
 
 use plume_models::{db_conn::DbConn, posts::Post, users::User};
@@ -11,11 +12,12 @@ pub fn tag(
     name: String,
     page: Option<Page>,
     intl: I18n,
+    msg: Option<FlashMessage>,
 ) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
     let posts = Post::list_by_tag(&*conn, name.clone(), page.limits())?;
     Ok(render!(tags::index(
-        &(&*conn, &intl.catalog, user),
+        &(&*conn, &intl.catalog, user, msg),
         name.clone(),
         posts,
         page.0,

--- a/src/routes/tags.rs
+++ b/src/routes/tags.rs
@@ -1,26 +1,16 @@
-use rocket::request::FlashMessage;
-use rocket_i18n::I18n;
-
-use plume_models::{db_conn::DbConn, posts::Post, users::User};
+use plume_models::{posts::Post, PlumeRocket};
 use routes::{errors::ErrorPage, Page};
-use template_utils::Ructe;
+use template_utils::{IntoContext, Ructe};
 
 #[get("/tag/<name>?<page>")]
-pub fn tag(
-    user: Option<User>,
-    conn: DbConn,
-    name: String,
-    page: Option<Page>,
-    intl: I18n,
-    msg: Option<FlashMessage>,
-) -> Result<Ructe, ErrorPage> {
+pub fn tag(name: String, page: Option<Page>, rockets: PlumeRocket) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
-    let posts = Post::list_by_tag(&*conn, name.clone(), page.limits())?;
+    let posts = Post::list_by_tag(&*rockets.conn, name.clone(), page.limits())?;
     Ok(render!(tags::index(
-        &(&*conn, &intl.catalog, user, msg),
+        &rockets.to_context(),
         name.clone(),
         posts,
         page.0,
-        Page::total(Post::count_for_tag(&*conn, name)? as i32)
+        Page::total(Post::count_for_tag(&*rockets.conn, name)? as i32)
     )))
 }

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -121,7 +121,12 @@ pub fn details(
 }
 
 #[get("/dashboard")]
-pub fn dashboard(user: User, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn dashboard(
+    user: User,
+    conn: DbConn,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     let blogs = Blog::find_for_author(&*conn, &user)?;
     Ok(render!(users::dashboard(
         &(&*conn, &intl.catalog, Some(user.clone()), msg),
@@ -142,7 +147,11 @@ pub fn dashboard_auth(i18n: I18n) -> Flash<Redirect> {
 }
 
 #[post("/@/<name>/follow")]
-pub fn follow(name: String, user: User, rockets: PlumeRocket) -> Result<Flash<Redirect>, ErrorPage> {
+pub fn follow(
+    name: String,
+    user: User,
+    rockets: PlumeRocket,
+) -> Result<Flash<Redirect>, ErrorPage> {
     let conn = &*rockets.conn;
     let target = User::find_by_fqn(&rockets, &name)?;
     let message = if let Ok(follow) = follows::Follow::find(&*conn, user.id, target.id) {
@@ -175,7 +184,10 @@ pub fn follow(name: String, user: User, rockets: PlumeRocket) -> Result<Flash<Re
             .execute(move || broadcast(&user, act, vec![target]));
         msg
     };
-    Ok(Flash::success(Redirect::to(uri!(details: name = name)), message))
+    Ok(Flash::success(
+        Redirect::to(uri!(details: name = name)),
+        message,
+    ))
 }
 
 #[post("/@/<name>/follow", data = "<remote_form>", rank = 2)]
@@ -319,7 +331,12 @@ pub fn activity_details(
 }
 
 #[get("/users/new")]
-pub fn new(user: Option<User>, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn new(
+    user: Option<User>,
+    conn: DbConn,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     Ok(render!(users::new(
         &(&*conn, &intl.catalog, user, msg),
         Instance::get_local(&*conn)?.open_registrations,
@@ -329,7 +346,13 @@ pub fn new(user: Option<User>, conn: DbConn, intl: I18n, msg: Option<FlashMessag
 }
 
 #[get("/@/<name>/edit")]
-pub fn edit(name: String, user: User, conn: DbConn, intl: I18n, msg: Option<FlashMessage>) -> Result<Ructe, ErrorPage> {
+pub fn edit(
+    name: String,
+    user: User,
+    conn: DbConn,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Ructe, ErrorPage> {
     if user.username == name && !name.contains('@') {
         Ok(render!(users::edit(
             &(&*conn, &intl.catalog, Some(user.clone()), msg),
@@ -389,7 +412,10 @@ pub fn update(
             user.summary.to_string()
         },
     )?;
-    Ok(Flash::success(Redirect::to(uri!(me)), i18n!(intl.catalog, "Your profile have been updated.")))
+    Ok(Flash::success(
+        Redirect::to(uri!(me)),
+        i18n!(intl.catalog, "Your profile have been updated."),
+    ))
 }
 
 #[post("/@/<name>/delete")]
@@ -408,9 +434,15 @@ pub fn delete(
             cookies.remove_private(cookie);
         }
 
-        Ok(Flash::success(Redirect::to(uri!(super::instance::index)), i18n!(intl.catalog, "Your account have been deleted.")))
+        Ok(Flash::success(
+            Redirect::to(uri!(super::instance::index)),
+            i18n!(intl.catalog, "Your account have been deleted."),
+        ))
     } else {
-        Ok(Flash::error(Redirect::to(uri!(edit: name = name)), i18n!(intl.catalog, "You can't delete someone else's account.")))
+        Ok(Flash::error(
+            Redirect::to(uri!(edit: name = name)),
+            i18n!(intl.catalog, "You can't delete someone else's account."),
+        ))
     }
 }
 
@@ -467,12 +499,20 @@ fn to_validation(_: Error) -> ValidationErrors {
 }
 
 #[post("/users/new", data = "<form>")]
-pub fn create(conn: DbConn, form: LenientForm<NewUserForm>, intl: I18n, msg: Option<FlashMessage>) -> Result<Flash<Redirect>, Ructe> {
+pub fn create(
+    conn: DbConn,
+    form: LenientForm<NewUserForm>,
+    intl: I18n,
+    msg: Option<FlashMessage>,
+) -> Result<Flash<Redirect>, Ructe> {
     if !Instance::get_local(&*conn)
         .map(|i| i.open_registrations)
         .unwrap_or(true)
     {
-        return Ok(Flash::error(Redirect::to(uri!(new)), i18n!(intl.catalog, "Registrations are closed on this instance."))); // Actually, it is an error
+        return Ok(Flash::error(
+            Redirect::to(uri!(new)),
+            i18n!(intl.catalog, "Registrations are closed on this instance."),
+        )); // Actually, it is an error
     }
 
     let mut form = form.into_inner();
@@ -490,7 +530,13 @@ pub fn create(conn: DbConn, form: LenientForm<NewUserForm>, intl: I18n, msg: Opt
                 User::hash_pass(&form.password).map_err(to_validation)?,
             )
             .map_err(to_validation)?;
-            Ok(Flash::success(Redirect::to(uri!(super::session::new: m = _)), i18n!(intl.catalog, "Your account have been created. You just need to login before you can use it.")))
+            Ok(Flash::success(
+                Redirect::to(uri!(super::session::new: m = _)),
+                i18n!(
+                    intl.catalog,
+                    "Your account have been created. You just need to login before you can use it."
+                ),
+            ))
         })
         .map_err(|err| {
             render!(users::new(

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -13,7 +13,12 @@ pub use askama_escape::escape;
 
 pub static CACHE_NAME: &str = env!("CACHE_ID");
 
-pub type BaseContext<'a, 'r> = &'a (&'a Connection, &'a Catalog, Option<User>, Option<FlashMessage<'a, 'r>>);
+pub type BaseContext<'a, 'r> = &'a (
+    &'a Connection,
+    &'a Catalog,
+    Option<User>,
+    Option<FlashMessage<'a, 'r>>,
+);
 
 #[derive(Debug)]
 pub struct Ructe(pub Vec<u8>);

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -2,7 +2,7 @@ use plume_models::{notifications::*, users::User, Connection};
 
 use rocket::http::hyper::header::{ETag, EntityTag};
 use rocket::http::{Method, Status};
-use rocket::request::Request;
+use rocket::request::{FlashMessage, Request};
 use rocket::response::{self, content::Html as HtmlCt, Responder, Response};
 use rocket_i18n::Catalog;
 use std::collections::hash_map::DefaultHasher;
@@ -13,7 +13,7 @@ pub use askama_escape::escape;
 
 pub static CACHE_NAME: &str = env!("CACHE_ID");
 
-pub type BaseContext<'a> = &'a (&'a Connection, &'a Catalog, Option<User>);
+pub type BaseContext<'a, 'r> = &'a (&'a Connection, &'a Catalog, Option<User>, Option<FlashMessage<'a, 'r>>);
 
 #[derive(Debug)]
 pub struct Ructe(pub Vec<u8>);

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -1,8 +1,8 @@
-use plume_models::{notifications::*, users::User, Connection};
+use plume_models::{notifications::*, users::User, Connection, PlumeRocket};
 
 use rocket::http::hyper::header::{ETag, EntityTag};
 use rocket::http::{Method, Status};
-use rocket::request::{FlashMessage, Request};
+use rocket::request::Request;
 use rocket::response::{self, content::Html as HtmlCt, Responder, Response};
 use rocket_i18n::Catalog;
 use std::collections::hash_map::DefaultHasher;
@@ -13,12 +13,41 @@ pub use askama_escape::escape;
 
 pub static CACHE_NAME: &str = env!("CACHE_ID");
 
-pub type BaseContext<'a, 'r> = &'a (
+pub type BaseContext<'a> = &'a (
     &'a Connection,
     &'a Catalog,
     Option<User>,
-    Option<FlashMessage<'a, 'r>>,
+    Option<(String, String)>,
 );
+
+pub trait IntoContext {
+    fn to_context<'a>(
+        &'a self,
+    ) -> (
+        &'a Connection,
+        &'a Catalog,
+        Option<User>,
+        Option<(String, String)>,
+    );
+}
+
+impl IntoContext for PlumeRocket {
+    fn to_context<'a>(
+        &'a self,
+    ) -> (
+        &'a Connection,
+        &'a Catalog,
+        Option<User>,
+        Option<(String, String)>,
+    ) {
+        (
+            &*self.conn,
+            &self.intl.catalog,
+            self.user.clone(),
+            self.flash_msg.clone(),
+        )
+    }
+}
 
 #[derive(Debug)]
 pub struct Ructe(pub Vec<u8>);

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -21,22 +21,22 @@ pub type BaseContext<'a> = &'a (
 );
 
 pub trait IntoContext {
-    fn to_context<'a>(
-        &'a self,
+    fn to_context(
+        &self,
     ) -> (
-        &'a Connection,
-        &'a Catalog,
+        &Connection,
+        &Catalog,
         Option<User>,
         Option<(String, String)>,
     );
 }
 
 impl IntoContext for PlumeRocket {
-    fn to_context<'a>(
-        &'a self,
+    fn to_context(
+        &self,
     ) -> (
-        &'a Connection,
-        &'a Catalog,
+        &Connection,
+        &Catalog,
         Option<User>,
         Option<(String, String)>,
     ) {

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -76,14 +76,27 @@ header {
 
 .messages {
   & > * {
-      padding: 1em 20%;
+    padding: 1em 20%;
+    margin: 0;
+    max-width: initial;
+    font-weight: bold;
   }
 
   p.error {
-    color: $red;
+    color: darken($red, 20%);
     background: lighten($red, 40%);
     margin: 0;
     max-width: initial;
+  }
+
+  p.warning {
+    color: darken($yellow, 20%);
+    background: lighten($yellow, 40%);
+  }
+
+  p.success {
+    color: darken($green, 20%);
+    background: lighten($green, 40%);
   }
 }
 

--- a/static/css/_variables.scss
+++ b/static/css/_variables.scss
@@ -8,6 +8,8 @@ $white: #F4F4F4;
 $purple: #7765E3;
 $lightpurple: #c2bbee;
 $red: #E92F2F;
+$yellow: #ffe347;
+$green: #23f0c7;
 
 // Fonts
 

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -70,9 +70,6 @@
             </div>
         </header>
         <div class="messages">
-            <p class="flash-message error">Error!</p>
-            <p class="flash-message success">Success!</p>
-            <p class="flash-message warning">Warning!</p>
             @if let Some(ref message) = ctx.3 {
                 <p class="flash-message @message.name()">@message.msg()</p>
             }

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -69,9 +69,14 @@
                 </nav>
             </div>
         </header>
-        @if let Some(ref message) = ctx.3 {
-            <div class="flash-message @message.name()">@message.msg()</div>
-        }
+        <div class="messages">
+            <p class="flash-message error">Error!</p>
+            <p class="flash-message success">Success!</p>
+            <p class="flash-message warning">Warning!</p>
+            @if let Some(ref message) = ctx.3 {
+                <p class="flash-message @message.name()">@message.msg()</p>
+            }
+        </div>
         <main>
             @:content()
         </main>

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -69,6 +69,9 @@
                 </nav>
             </div>
         </header>
+        @if let Some(ref message) = ctx.3 {
+            <div class="flash-message @message.name()">@message.msg()</div>
+        }
         <main>
             @:content()
         </main>

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -71,7 +71,7 @@
         </header>
         <div class="messages">
             @if let Some(ref message) = ctx.3 {
-                <p class="flash-message @message.name()">@message.msg()</p>
+                <p class="flash-message @message.0">@message.1</p>
             }
         </div>
         <main>


### PR DESCRIPTION
Here is an example of what it looks like (this is just a test, in reality you can only have one of these messages at the same time):

![Screenshot_2019-04-27 Plume unu ⋅ Plume](https://user-images.githubusercontent.com/16254623/56852089-77178700-690e-11e9-88fc-acb089b58fef.png)

I don't know if there is a simpler way to do it. Also, I added `msg: Option<FlashMessage>` to almost all routes to be sure that if a message was present it would be rendered, but maybe it is not necessary and only make the code harder to read? And maybe `msg` should go in `PlumeRocket` as it is used almost everywhere?

Fixes #468