### PR TITLE
Basic CSS rules to keep content in iPhone X safe area

### DIFF
--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -30,8 +30,6 @@ main article {
 
   pre {
    	padding: 1em;
-    padding: env(safe-area-inset-right)
-             env(safe-area-inset-left);
    	background: $lightgray;
    	overflow: auto;
    	border-radius: 5px;
@@ -41,8 +39,8 @@ main article {
 // Metadata under the article
 main .article-meta, main .article-meta button {
   padding: 0;
-  padding:  env(safe-area-inset-right)
-             env(safe-area-inset-left);
+  padding: env(safe-area-inset-right)
+           env(safe-area-inset-left);
   font-size: 1.1em;
   margin-top: 10%;
 }
@@ -51,8 +49,8 @@ main .article-meta {
 
   > * {
     margin: 0 20%;
-    margin:  env(safe-area-inset-right)
-             env(safe-area-inset-left);
+    margin: env(safe-area-inset-right)
+            env(safe-area-inset-left);
   }
 
   > p {

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -58,7 +58,7 @@ main .article-meta {
    }
 
   > p {
-    @supports(margin: max(0px)) {
+    @supports(margin: max(2em)) {
     margin: 2em 20%;
     margin: env(safe-area-inset-right)
             env(safe-area-inset-left);
@@ -100,7 +100,7 @@ main .article-meta {
   }
 
   // Likes & Boosts
-  @supports(padding: max(0px)) {
+  @supports(padding: max(0.5em)) {
   .actions {
     display: flex;
     display: -webkit-flex;
@@ -169,6 +169,7 @@ main .article-meta {
   .likes {
     p, .action:hover { color: $red; }
 
+    @supports(padding: max(0.7em)) {
     .action svg.feather {
       padding: 0.7em;
       padding: env(safe-area-inset-right)
@@ -178,6 +179,7 @@ main .article-meta {
      	fill: none;
      	border: solid $red thin;
     }
+     }
 
     .action:hover svg.feather {
      	background: transparentize($red, 0.85);
@@ -193,6 +195,7 @@ main .article-meta {
     }
   }
 
+  @supports(padding: max(0.7em)) {
   .reshares {
     p, .action:hover { color: $purple; }
 
@@ -205,6 +208,7 @@ main .article-meta {
      	border: solid $purple thin;
      	font-weight: 600;
     }
+     }
 
     .action:hover svg.feather {
      	background: transparentize($purple, 0.85);
@@ -220,6 +224,7 @@ main .article-meta {
   }
 
   // Comments
+  @supports(margin: max(0px)) {
   .comments {
     margin: 0;
     margin: env(safe-area-inset-right)
@@ -238,6 +243,7 @@ main .article-meta {
     summary {
       cursor: pointer;
     }
+     }
 
     // New comment form
     > form input[type="submit"] {
@@ -245,6 +251,7 @@ main .article-meta {
     }
 
     // Respond & delete comment buttons
+    @supports(padding: max(0px)) {
     a.button, form.inline, form.inline input {
      	display: inline-block;
      	padding: 0;
@@ -262,7 +269,6 @@ main .article-meta {
       &:hover { color: $purple; }
     }
     
-    @supports(padding: max(0px)) {
     .list {
      	display: grid;
      	margin: 0 0 -5em;
@@ -317,6 +323,7 @@ main .article-meta {
 }
 
 #plume-editor {
+  @supports(margin: max(1em)) {
   header {
     display: flex;
     display: -webkit-flex;
@@ -333,6 +340,7 @@ main .article-meta {
               env(safe-area-inset-left);
     }
   }
+   }
 
   & > * {
     min-height: 1em;
@@ -351,6 +359,7 @@ main .article-meta {
 }
 
 .popup {
+  @supports(padding: max(2em)) {
   position: fixed;
   top: 15vh;
   bottom: 20vh;
@@ -365,6 +374,7 @@ main .article-meta {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
+ }
 
 .popup:not(.show), .popup-bg:not(.show) {
     display: none;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -28,13 +28,17 @@ main article {
    	max-width: 100%;
   }
 
+  @supports(padding: max(1em)) {
   pre {
    	padding: 1em;
+    padding: env(safe-area-inset-right)
+             env(safe-area-inset-left);
    	background: $lightgray;
    	overflow: auto;
    	border-radius: 5px;
   }
 }
+ }
 
 // Metadata under the article
 @supports(padding: max(0px)) {
@@ -49,16 +53,16 @@ main .article-meta, main .article-meta button {
 
 main .article-meta {
 
+  @supports(margin: max(0px)) {
   > * {
-    @supports(margin: max(0px)) {
     margin: 0 20%;
     margin: env(safe-area-inset-right)
             env(safe-area-inset-left);
   }
    }
 
+  @supports(margin: max(2em)) {
   > p {
-    @supports(margin: max(2em)) {
     margin: 2em 20%;
     margin: env(safe-area-inset-right)
             env(safe-area-inset-left);

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -30,6 +30,10 @@ main article {
 
   pre {
    	padding: 1em;
+    padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
    	background: $lightgray;
    	overflow: auto;
    	border-radius: 5px;
@@ -39,6 +43,10 @@ main article {
 // Metadata under the article
 main .article-meta, main .article-meta button {
   padding: 0;
+  padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   font-size: 1.1em;
   margin-top: 10%;
 }
@@ -60,6 +68,10 @@ main .article-meta {
     display: inline-block;
     display: -webkit-inline-block;
     padding: 0px;
+    padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
     margin-bottom: 2em;
 
     li {
@@ -67,6 +79,10 @@ main .article-meta {
       display: -webkit-inline-block;
       background: $lightgray;
       padding: 0px;
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
       margin: 0px 10px 10px 0px;
       border-radius: 3px;
       transition: all 0.2s ease-in;
@@ -98,6 +114,10 @@ main .article-meta {
    	flex-direction: column;
    	align-items: center;
    	padding: 0.5em 0;
+    padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
 
     p {
       font-size: 1.5em;
@@ -114,6 +134,10 @@ main .article-meta {
      	justify-content: center;
      	margin: 0;
      	padding: 0;
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	background: none;
      	color: $black;
      	border: none;
@@ -147,6 +171,10 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $red;
      	fill: none;
@@ -217,8 +245,11 @@ main .article-meta {
     // Respond & delete comment buttons
     a.button, form.inline, form.inline input {
      	display: inline-block;
-      display: -webkit-inline-block;
      	padding: 0;
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	background: none;
      	color: $black;
      	border: none;
@@ -269,6 +300,10 @@ main .article-meta {
 
      	.text {
        	padding: 1.25em 0;
+        padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
        	font-family: $lora;
        	font-size: 1.1em;
        	line-height: 1.4;
@@ -320,6 +355,10 @@ main .article-meta {
   border: 1px solid $purple;
   z-index: 2;
   padding: 2em;
+  padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -343,7 +382,6 @@ main .article-meta {
 .cw-container {
   position: relative;
   display: inline-block;
-  display: -webkit-inline-block;
 }
 
 .cw-text {
@@ -366,7 +404,6 @@ input:checked ~ .cw-container:before {
 
 input:checked ~ .cw-container > .cw-text {
   display: inline;
-  display: -webkit-inline;
   position: absolute;
   color: white;
   width: 100%;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -2,8 +2,6 @@
 main .article-info {
   max-width: 40rem;
  	margin: 0 auto 3em;
-  margin: env(safe-area-inset-right)
-           env(safe-area-inset-left);
  	font-size: 0.95em;
  	font-weight: 400;
 
@@ -84,16 +82,12 @@ main .article-meta {
       padding: env(safe-area-inset-right)
                env(safe-area-inset-left);
       margin: 0px 10px 10px 0px;
-      margin: env(safe-area-inset-right)
-              env(safe-area-inset-left);
       border-radius: 3px;
       transition: all 0.2s ease-in;
 
       a {
         display: inline-block;
         padding: 10px 20px;
-        padding: env(safe-area-inset-right)
-                 env(safe-area-inset-left);
         color: $black;
       }
 
@@ -151,8 +145,6 @@ main .article-meta {
        	justify-content: center;
 
        	margin: 0.5em 0;
-        margin: env(safe-area-inset-right)
-                 env(safe-area-inset-left);
        	width: 2.5em;
        	height: 2.5em;
 
@@ -173,8 +165,6 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
-      padding: env(safe-area-inset-right)
-               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $red;
      	fill: none;
@@ -200,8 +190,6 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
-      padding: env(safe-area-inset-right)
-               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $purple;
      	border: solid $purple thin;
@@ -261,7 +249,6 @@ main .article-meta {
      	&::before {
      	  color: $purple;
      	  padding-right: 0.5em;
-          padding-right: env(safe-area-inset-right);
       }
 
       &:hover { color: $purple; }

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -58,11 +58,13 @@ main .article-meta {
   .tags {
     list-style: none;
     display: inline-block;
+    display: -webkit-inline-block;
     padding: 0px;
     margin-bottom: 2em;
 
     li {
       display: inline-block;
+      display: -webkit-inline-block;
       background: $lightgray;
       padding: 0px;
       margin: 0px 10px 10px 0px;
@@ -71,6 +73,7 @@ main .article-meta {
 
       a {
         display: inline-block;
+        display: -webkit-inline-block;
         padding: 10px 20px;
         color: $black;
       }
@@ -99,6 +102,7 @@ main .article-meta {
     p {
       font-size: 1.5em;
       display: inline-block;
+      display: -webkit-inline-block;
       margin: 0;
     }
 
@@ -213,6 +217,7 @@ main .article-meta {
     // Respond & delete comment buttons
     a.button, form.inline, form.inline input {
      	display: inline-block;
+      display: -webkit-inline-block;
      	padding: 0;
      	background: none;
      	color: $black;
@@ -335,6 +340,7 @@ main .article-meta {
 .cw-container {
   position: relative;
   display: inline-block;
+  display: -webkit-inline-block;
 }
 
 .cw-text {
@@ -355,6 +361,7 @@ input:checked ~ .cw-container:before {
 
 input:checked ~ .cw-container > .cw-text {
   display: inline;
+  display: -webkit-inline-block;
   position: absolute;
   color: white;
   width: 100%;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -84,12 +84,14 @@ main .article-meta {
   // Likes & Boosts
   .actions {
     display: flex;
+    display: -webkit-flex;
    	flex-direction: row;
    	justify-content: space-around;
   }
 
   .likes, .reshares {
     display: flex;
+    display: -webkit-flex;
    	flex-direction: column;
    	align-items: center;
    	padding: 0.5em 0;
@@ -102,6 +104,7 @@ main .article-meta {
 
     .action {
       display: flex;
+      display: -webkit-flex;
      	flex-direction: column;
      	align-items: center;
      	justify-content: center;
@@ -115,6 +118,7 @@ main .article-meta {
      	svg.feather {
        	transition: background 0.1s ease-in;
        	display: flex;
+        display: -webkit-flex;
        	align-items: center;
        	justify-content: center;
 
@@ -219,6 +223,7 @@ main .article-meta {
      	&::before {
      	  color: $purple;
      	  padding-right: 0.5em;
+        padding-right: env(safe-area-inset-right);
       }
 
       &:hover { color: $purple; }
@@ -238,6 +243,7 @@ main .article-meta {
 
      	.author {
      	  display: flex;
+        display: -webkit-flex;
        	flex-direction: row;
        	align-items: center;
        	align-content: center;
@@ -270,6 +276,7 @@ main .article-meta {
 #plume-editor {
   header {
     display: flex;
+    display: -webkit-flex;
     flex-direction: row-reverse;
     background: transparent;
     align-items: center;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -37,6 +37,7 @@ main article {
 }
 
 // Metadata under the article
+@supports(padding: max(0px)) {
 main .article-meta, main .article-meta button {
   padding: 0;
   padding: env(safe-area-inset-right)
@@ -44,6 +45,7 @@ main .article-meta, main .article-meta button {
   font-size: 1.1em;
   margin-top: 10%;
 }
+ }
 
 main .article-meta {
 
@@ -61,6 +63,7 @@ main .article-meta {
   }
 
   // Article Tags
+  @supports(padding: max(0px)) {
   .tags {
     list-style: none;
     display: inline-block;
@@ -84,6 +87,7 @@ main .article-meta {
         padding: 10px 20px;
         color: $black;
       }
+    }
 
       &:hover {
         background: mix($black, $lightgray, 10%);
@@ -115,7 +119,8 @@ main .article-meta {
       margin: env(safe-area-inset-right)
               env(safe-area-inset-left);
     }
-
+    
+    @supports(padding: max(0px)) {
     .action {
       display: flex;
       display: -webkit-flex;
@@ -144,6 +149,7 @@ main .article-meta {
 
        	border-radius: 50%;
       }
+       }
 
       &.reshared, &.liked {
         svg.feather {
@@ -249,7 +255,8 @@ main .article-meta {
 
       &:hover { color: $purple; }
     }
-
+    
+    @supports(padding: max(0px)) {
     .list {
      	display: grid;
      	margin: 0 0 -5em;
@@ -260,6 +267,7 @@ main .article-meta {
                env(safe-area-inset-left);
      	background: $lightgray;
     }
+     }
 
     .comment {
       padding: 2em;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -321,10 +321,12 @@ main .article-meta {
   z-index: 2;
   padding: 2em;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .popup:not(.show), .popup-bg:not(.show) {
     display: none;
+    -webkit-appearance: none;
 }
 
 .popup-bg {

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -362,8 +362,8 @@ main .article-meta {
   }
 }
 
+@supports(padding: max(2em)) {
 .popup {
-  @supports(padding: max(2em)) {
   position: fixed;
   top: 15vh;
   bottom: 20vh;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -50,17 +50,21 @@ main .article-meta, main .article-meta button {
 main .article-meta {
 
   > * {
+    @supports(margin: max(0px)) {
     margin: 0 20%;
     margin: env(safe-area-inset-right)
             env(safe-area-inset-left);
   }
+   }
 
   > p {
+    @supports(margin: max(0px)) {
     margin: 2em 20%;
     margin: env(safe-area-inset-right)
             env(safe-area-inset-left);
  	  font-size: 0.9em;
   }
+   }
 
   // Article Tags
   @supports(padding: max(0px)) {

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -100,6 +100,7 @@ main .article-meta {
   }
 
   // Likes & Boosts
+  @supports(padding: max(0px)) {
   .actions {
     display: flex;
     display: -webkit-flex;
@@ -123,6 +124,7 @@ main .article-meta {
       margin: env(safe-area-inset-right)
               env(safe-area-inset-left);
     }
+     }
     
     @supports(padding: max(0px)) {
     .action {

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -2,9 +2,7 @@
 main .article-info {
   max-width: 40rem;
  	margin: 0 auto 3em;
-  margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
+  margin: env(safe-area-inset-right)
            env(safe-area-inset-left);
  	font-size: 0.95em;
  	font-weight: 400;
@@ -18,9 +16,7 @@ main .article-info {
 main article {
   max-width: 40rem;
  	margin: 2.5em auto;
-  margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
+  margin: env(safe-area-inset-right)
            env(safe-area-inset-left);
  	font-family: $lora;
  	font-size: 1.2em;
@@ -33,19 +29,15 @@ main article {
  	img {
    	display: block;
    	margin: 3em auto;
-    margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    margin: env(safe-area-inset-right)
+            env(safe-area-inset-left);
    	max-width: 100%;
   }
 
   pre {
    	padding: 1em;
-    padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    padding: env(safe-area-inset-right)
+             env(safe-area-inset-left);
    	background: $lightgray;
    	overflow: auto;
    	border-radius: 5px;
@@ -55,10 +47,8 @@ main article {
 // Metadata under the article
 main .article-meta, main .article-meta button {
   padding: 0;
-  padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  padding: env(safe-area-inset-right)
+             env(safe-area-inset-left);
   font-size: 1.1em;
   margin-top: 10%;
 }
@@ -67,18 +57,14 @@ main .article-meta {
 
   > * {
     margin: 0 20%;
-    margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    margin:  env(safe-area-inset-right)
+             env(safe-area-inset-left);
   }
 
   > p {
     margin: 2em 20%;
-    margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    margin: env(safe-area-inset-right)
+            env(safe-area-inset-left);
  	  font-size: 0.9em;
   }
 
@@ -87,35 +73,27 @@ main .article-meta {
     list-style: none;
     display: inline-block;
     padding: 0px;
-    padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    padding: env(safe-area-inset-right)
+             env(safe-area-inset-left);
     margin-bottom: 2em;
 
     li {
       display: inline-block;
       background: $lightgray;
       padding: 0px;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
       margin: 0px 10px 10px 0px;
-      margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right)
+              env(safe-area-inset-left);
       border-radius: 3px;
       transition: all 0.2s ease-in;
 
       a {
         display: inline-block;
         padding: 10px 20px;
-        padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+        padding: env(safe-area-inset-right)
+                 env(safe-area-inset-left);
         color: $black;
       }
 
@@ -139,19 +117,15 @@ main .article-meta {
    	flex-direction: column;
    	align-items: center;
    	padding: 0.5em 0;
-    padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    padding: env(safe-area-inset-right)
+             env(safe-area-inset-left);
 
     p {
       font-size: 1.5em;
       display: inline-block;
       margin: 0;
-      margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right)
+              env(safe-area-inset-left);
     }
 
     .action {
@@ -162,10 +136,8 @@ main .article-meta {
      	justify-content: center;
      	margin: 0;
      	padding: 0;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	background: none;
      	color: $black;
      	border: none;
@@ -179,10 +151,8 @@ main .article-meta {
        	justify-content: center;
 
        	margin: 0.5em 0;
-        margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+        margin: env(safe-area-inset-right)
+                 env(safe-area-inset-left);
        	width: 2.5em;
        	height: 2.5em;
 
@@ -203,10 +173,8 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $red;
      	fill: none;
@@ -232,10 +200,8 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $purple;
      	border: solid $purple thin;
@@ -258,10 +224,8 @@ main .article-meta {
   // Comments
   .comments {
     margin: 0;
-    margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    margin: env(safe-area-inset-right)
+             env(safe-area-inset-left);
     > * {
       margin-left: 20%;
       margin-right: 20%;
@@ -286,10 +250,8 @@ main .article-meta {
     a.button, form.inline, form.inline input {
      	display: inline-block;
      	padding: 0;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	background: none;
      	color: $black;
      	border: none;
@@ -308,24 +270,18 @@ main .article-meta {
     .list {
      	display: grid;
      	margin: 0 0 -5em;
-      margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	padding: 0 20%;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	background: $lightgray;
     }
 
     .comment {
       padding: 2em;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	font-size: 1em;
      	border: none;
 
@@ -352,10 +308,8 @@ main .article-meta {
 
      	.text {
        	padding: 1.25em 0;
-        padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+        padding: env(safe-area-inset-right)
+                 env(safe-area-inset-left);
        	font-family: $lora;
        	font-size: 1.1em;
        	line-height: 1.4;
@@ -378,10 +332,8 @@ main .article-meta {
       -webkit-flex: 0 0 10em;
       font-size: 1.25em;
       margin: .5em 0em .5em 1em;
-      margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right)
+              env(safe-area-inset-left);
     }
   }
 
@@ -411,9 +363,7 @@ main .article-meta {
   border: 1px solid $purple;
   z-index: 2;
   padding: 2em;
-  padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
+  padding: env(safe-area-inset-right)
            env(safe-area-inset-left);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -2,6 +2,10 @@
 main .article-info {
   max-width: 40rem;
  	margin: 0 auto 3em;
+  margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
  	font-size: 0.95em;
  	font-weight: 400;
 
@@ -14,6 +18,10 @@ main .article-info {
 main article {
   max-width: 40rem;
  	margin: 2.5em auto;
+  margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
  	font-family: $lora;
  	font-size: 1.2em;
  	line-height: 1.7;
@@ -25,14 +33,18 @@ main article {
  	img {
    	display: block;
    	margin: 3em auto;
+    margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
    	max-width: 100%;
   }
 
   pre {
    	padding: 1em;
-    padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+    padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
    	background: $lightgray;
    	overflow: auto;
@@ -43,9 +55,9 @@ main article {
 // Metadata under the article
 main .article-meta, main .article-meta button {
   padding: 0;
-  padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
   font-size: 1.1em;
   margin-top: 10%;
@@ -55,10 +67,18 @@ main .article-meta {
 
   > * {
     margin: 0 20%;
+    margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
   }
 
   > p {
     margin: 2em 20%;
+    margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
  	  font-size: 0.9em;
   }
 
@@ -66,31 +86,36 @@ main .article-meta {
   .tags {
     list-style: none;
     display: inline-block;
-    display: -webkit-inline-block;
     padding: 0px;
-    padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+    padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
     margin-bottom: 2em;
 
     li {
       display: inline-block;
-      display: -webkit-inline-block;
       background: $lightgray;
       padding: 0px;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
       margin: 0px 10px 10px 0px;
+      margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
       border-radius: 3px;
       transition: all 0.2s ease-in;
 
       a {
         display: inline-block;
-        display: -webkit-inline-block;
         padding: 10px 20px;
+        padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
         color: $black;
       }
 
@@ -114,16 +139,19 @@ main .article-meta {
    	flex-direction: column;
    	align-items: center;
    	padding: 0.5em 0;
-    padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+    padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
 
     p {
       font-size: 1.5em;
       display: inline-block;
-      display: -webkit-inline-block;
       margin: 0;
+      margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
     }
 
     .action {
@@ -134,9 +162,9 @@ main .article-meta {
      	justify-content: center;
      	margin: 0;
      	padding: 0;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
      	background: none;
      	color: $black;
@@ -151,6 +179,10 @@ main .article-meta {
        	justify-content: center;
 
        	margin: 0.5em 0;
+        margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
        	width: 2.5em;
        	height: 2.5em;
 
@@ -171,9 +203,9 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $red;
@@ -200,6 +232,10 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $purple;
      	border: solid $purple thin;
@@ -222,6 +258,10 @@ main .article-meta {
   // Comments
   .comments {
     margin: 0;
+    margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
     > * {
       margin-left: 20%;
       margin-right: 20%;
@@ -246,9 +286,9 @@ main .article-meta {
     a.button, form.inline, form.inline input {
      	display: inline-block;
      	padding: 0;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
      	background: none;
      	color: $black;
@@ -259,7 +299,7 @@ main .article-meta {
      	&::before {
      	  color: $purple;
      	  padding-right: 0.5em;
-        padding-right: env(safe-area-inset-right);
+          padding-right: env(safe-area-inset-right);
       }
 
       &:hover { color: $purple; }
@@ -268,12 +308,24 @@ main .article-meta {
     .list {
      	display: grid;
      	margin: 0 0 -5em;
+      margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
      	padding: 0 20%;
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
      	background: $lightgray;
     }
 
     .comment {
       padding: 2em;
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
      	font-size: 1em;
      	border: none;
 
@@ -300,9 +352,9 @@ main .article-meta {
 
      	.text {
        	padding: 1.25em 0;
-        padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+        padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
        	font-family: $lora;
        	font-size: 1.1em;
@@ -326,6 +378,10 @@ main .article-meta {
       -webkit-flex: 0 0 10em;
       font-size: 1.25em;
       margin: .5em 0em .5em 1em;
+      margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
     }
   }
 
@@ -355,9 +411,9 @@ main .article-meta {
   border: 1px solid $purple;
   z-index: 2;
   padding: 2em;
-  padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -159,6 +159,8 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $red;
      	fill: none;
@@ -184,6 +186,8 @@ main .article-meta {
 
     .action svg.feather {
       padding: 0.7em;
+      padding: env(safe-area-inset-right)
+               env(safe-area-inset-left);
      	box-sizing: border-box;
      	color: $purple;
      	border: solid $purple thin;
@@ -232,8 +236,6 @@ main .article-meta {
     a.button, form.inline, form.inline input {
      	display: inline-block;
      	padding: 0;
-      padding: env(safe-area-inset-right)
-               env(safe-area-inset-left);
      	background: none;
      	color: $black;
      	border: none;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -14,8 +14,6 @@ main .article-info {
 main article {
   max-width: 40rem;
  	margin: 2.5em auto;
-  margin: env(safe-area-inset-right)
-           env(safe-area-inset-left);
  	font-family: $lora;
  	font-size: 1.2em;
  	line-height: 1.7;
@@ -27,8 +25,6 @@ main article {
  	img {
    	display: block;
    	margin: 3em auto;
-    margin: env(safe-area-inset-right)
-            env(safe-area-inset-left);
    	max-width: 100%;
   }
 
@@ -45,7 +41,7 @@ main article {
 // Metadata under the article
 main .article-meta, main .article-meta button {
   padding: 0;
-  padding: env(safe-area-inset-right)
+  padding:  env(safe-area-inset-right)
              env(safe-area-inset-left);
   font-size: 1.1em;
   margin-top: 10%;

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -282,6 +282,7 @@ main .article-meta {
      }
 
     .comment {
+      @supports(padding: max(2em)) {
       padding: 2em;
       padding: env(safe-area-inset-right)
                env(safe-area-inset-left);
@@ -307,9 +308,11 @@ main .article-meta {
           .display-name { color: $purple; }
           small { opacity: 1; }
         }
-     	}
+     	} 
+       }
 
      	.text {
+        @supports(padding: max(1.25em)) {
        	padding: 1.25em 0;
         padding: env(safe-area-inset-right)
                  env(safe-area-inset-left);
@@ -321,6 +324,7 @@ main .article-meta {
     }
   }
 }
+ }
 
 #plume-editor {
   @supports(margin: max(1em)) {

--- a/static/css/_article.scss
+++ b/static/css/_article.scss
@@ -288,6 +288,7 @@ main .article-meta {
     justify-content: space-between;
     button {
       flex: 0 0 10em;
+      -webkit-flex: 0 0 10em;
       font-size: 1.25em;
       margin: .5em 0em .5em 1em;
     }
@@ -345,10 +346,12 @@ main .article-meta {
 
 .cw-text {
   display: none;
+  -webkit-appearance: none;
 }
 
 input[type="checkbox"].cw-checkbox {
   display: none;
+  -webkit-appearance: none;
 }
 
 input:checked ~ .cw-container:before {
@@ -361,7 +364,7 @@ input:checked ~ .cw-container:before {
 
 input:checked ~ .cw-container > .cw-text {
   display: inline;
-  display: -webkit-inline-block;
+  display: -webkit-inline;
   position: absolute;
   color: white;
   width: 100%;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -136,6 +136,7 @@ form.new-post {
 
 .split {
   display: flex;
+  display: -webkit-flex;
   justify-content: space-between;
 
   & > * {
@@ -146,6 +147,7 @@ form.new-post {
 
 header.center {
   display: flex;
+  display: -webkit-flex;
   flex-direction: column;
   align-items: center;
   background: transparent;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -1,10 +1,8 @@
 label {
  	display: block;
  	margin: 2em auto .5em;
-  margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  margin: env(safe-area-inset-right)
+          env(safe-area-inset-left);
  	font-size: 1.2em;
 }
 input, textarea, select {
@@ -12,15 +10,11 @@ input, textarea, select {
  	display: block;
  	width: 100%;
  	margin: auto;
-  margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  margin: env(safe-area-inset-right)
+          env(safe-area-inset-left);
  	padding: 1em;
-  padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  padding: env(safe-area-inset-right)
+          env(safe-area-inset-left);
  	box-sizing: border-box;
 
  	background: $form-input-background;
@@ -57,15 +51,11 @@ input[type="checkbox"] {
 form.inline {
   display: inline;
   margin: 0px;
-  margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  margin: env(safe-area-inset-right)
+          env(safe-area-inset-left);
   padding: 0px;
-  padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  padding: env(safe-area-inset-right)
+          env(safe-area-inset-left);
   width: auto;
 
   input[type="submit"] {
@@ -78,15 +68,11 @@ form.inline {
 
     &:not(.button) {
       margin: 0;
-      margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right)
+          env(safe-area-inset-left);
       padding: 0;
-      padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+      padding: env(safe-area-inset-right)
+          env(safe-area-inset-left);
       border: none;
       background: transparent;
       color: $purple;
@@ -101,15 +87,11 @@ form.inline {
 
  	border-radius: 0.5em;
  	margin: 0.5em auto;
-  margin: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  margin: env(safe-area-inset-right)
+          env(safe-area-inset-left);
  	padding: 0.75em 1em;
-  padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+  padding: env(safe-area-inset-right)
+          env(safe-area-inset-left);
 
  	background: transparent;
  	color: $purple;
@@ -140,10 +122,8 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
-    padding: env(safe-area-inset-top)
-           env(safe-area-inset-right)
-           env(safe-area-inset-bottom)
-           env(safe-area-inset-left);
+    padding: env(safe-area-inset-right)
+          env(safe-area-inset-left);
 
    	background: none;
    	border: none;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -1,8 +1,6 @@
 label {
  	display: block;
  	margin: 2em auto .5em;
-  margin: env(safe-area-inset-right)
-          env(safe-area-inset-left);
  	font-size: 1.2em;
 }
 input, textarea, select {
@@ -10,11 +8,7 @@ input, textarea, select {
  	display: block;
  	width: 100%;
  	margin: auto;
-  margin: env(safe-area-inset-right)
-          env(safe-area-inset-left);
  	padding: 1em;
-  padding: env(safe-area-inset-right)
-          env(safe-area-inset-left);
  	box-sizing: border-box;
 
  	background: $form-input-background;
@@ -51,11 +45,7 @@ input[type="checkbox"] {
 form.inline {
   display: inline;
   margin: 0px;
-  margin: env(safe-area-inset-right)
-          env(safe-area-inset-left);
   padding: 0px;
-  padding: env(safe-area-inset-right)
-          env(safe-area-inset-left);
   width: auto;
 
   input[type="submit"] {
@@ -68,11 +58,7 @@ form.inline {
 
     &:not(.button) {
       margin: 0;
-      margin: env(safe-area-inset-right)
-          env(safe-area-inset-left);
       padding: 0;
-      padding: env(safe-area-inset-right)
-          env(safe-area-inset-left);
       border: none;
       background: transparent;
       color: $purple;
@@ -87,11 +73,7 @@ form.inline {
 
  	border-radius: 0.5em;
  	margin: 0.5em auto;
-  margin: env(safe-area-inset-right)
-          env(safe-area-inset-left);
  	padding: 0.75em 1em;
-  padding: env(safe-area-inset-right)
-          env(safe-area-inset-left);
 
  	background: transparent;
  	color: $purple;
@@ -122,8 +104,6 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
-    padding: env(safe-area-inset-right)
-          env(safe-area-inset-left);
 
    	background: none;
    	border: none;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -1,11 +1,13 @@
 label {
  	display: block;
+  display: -webkit-block;
  	margin: 2em auto .5em;
  	font-size: 1.2em;
 }
 input, textarea, select {
  	transition: all 0.1s ease-in;
  	display: block;
+  display: -webkit-block;
  	width: 100%;
  	margin: auto;
  	padding: 1em;
@@ -38,6 +40,7 @@ textarea {
 
 input[type="checkbox"] {
  	display: inline;
+  display: -webkit-inline;
  	margin: initial;
  	min-width: initial;
  	width: initial;
@@ -47,6 +50,7 @@ input[type="checkbox"] {
 
 form.inline {
   display: inline;
+  display: -webkit-inline;
   margin: 0px;
   padding: 0px;
   padding-top: env(safe-area-inset-top);
@@ -56,6 +60,7 @@ form.inline {
 
   input[type="submit"] {
     display: inline-block;
+    display: -webkit-inline-block;
     color: $purple;
     cursor: pointer;
     font-size: 1em;
@@ -75,6 +80,7 @@ form.inline {
 .button, input[type="submit"], button {
  	transition: all 0.1s ease-in;
  	display: inline-block;
+  display: -webkit-inline-block;
   -webkit-appearance: none;
 
  	border-radius: 0.5em;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -9,6 +9,8 @@ input, textarea, select {
  	width: 100%;
  	margin: auto;
  	padding: 1em;
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
  	box-sizing: border-box;
 
  	background: $form-input-background;
@@ -74,6 +76,8 @@ form.inline {
  	border-radius: 0.5em;
  	margin: 0.5em auto;
  	padding: 0.75em 1em;
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 
  	background: transparent;
  	color: $purple;
@@ -104,6 +108,8 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
 
    	background: none;
    	border: none;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -9,9 +9,10 @@ input, textarea, select {
  	width: 100%;
  	margin: auto;
  	padding: 1em;
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+  padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
  	box-sizing: border-box;
 
  	background: $form-input-background;
@@ -49,9 +50,10 @@ form.inline {
   display: inline;
   margin: 0px;
   padding: 0px;
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+  padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
   width: auto;
 
   input[type="submit"] {
@@ -80,9 +82,10 @@ form.inline {
  	border-radius: 0.5em;
  	margin: 0.5em auto;
  	padding: 0.75em 1em;
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+  padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
 
  	background: transparent;
  	color: $purple;
@@ -113,9 +116,10 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
-    padding-top: env(safe-area-inset-top);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
+    padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
 
    	background: none;
    	border: none;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -9,6 +9,7 @@ input, textarea, select {
  	width: 100%;
  	margin: auto;
  	padding: 1em;
+  padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
  	box-sizing: border-box;
@@ -48,6 +49,9 @@ form.inline {
   display: inline;
   margin: 0px;
   padding: 0px;
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
   width: auto;
 
   input[type="submit"] {
@@ -76,6 +80,7 @@ form.inline {
  	border-radius: 0.5em;
  	margin: 0.5em auto;
  	padding: 0.75em 1em;
+  padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
 
@@ -108,6 +113,7 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
+    padding-top: env(safe-area-inset-top);
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
 

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -1,13 +1,11 @@
 label {
  	display: block;
-  display: -webkit-block;
  	margin: 2em auto .5em;
  	font-size: 1.2em;
 }
 input, textarea, select {
  	transition: all 0.1s ease-in;
  	display: block;
-  display: -webkit-block;
  	width: 100%;
  	margin: auto;
  	padding: 1em;
@@ -40,7 +38,6 @@ textarea {
 
 input[type="checkbox"] {
  	display: inline;
-  display: -webkit-inline;
  	margin: initial;
  	min-width: initial;
  	width: initial;
@@ -50,7 +47,6 @@ input[type="checkbox"] {
 
 form.inline {
   display: inline;
-  display: -webkit-inline;
   margin: 0px;
   padding: 0px;
   padding-top: env(safe-area-inset-top);
@@ -60,7 +56,6 @@ form.inline {
 
   input[type="submit"] {
     display: inline-block;
-    display: -webkit-inline-block;
     color: $purple;
     cursor: pointer;
     font-size: 1em;
@@ -80,7 +75,6 @@ form.inline {
 .button, input[type="submit"], button {
  	transition: all 0.1s ease-in;
  	display: inline-block;
-  display: -webkit-inline-block;
   -webkit-appearance: none;
 
  	border-radius: 0.5em;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -23,7 +23,10 @@ input, textarea, select {
  	  border-color: $purple;
  	}
 }
-form input[type="submit"] { margin: 2em auto; }
+form input[type="submit"] { 
+ margin: 2em auto;
+ -webkit-appearance: none;
+}
 
 textarea {
  	resize: vertical;
@@ -54,7 +57,7 @@ form.inline {
     cursor: pointer;
     font-size: 1em;
     width: auto;
-   -webkit-appearance: none;
+    -webkit-appearance: none;
 
     &:not(.button) {
       margin: 0;

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -1,6 +1,10 @@
 label {
  	display: block;
  	margin: 2em auto .5em;
+  margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
  	font-size: 1.2em;
 }
 input, textarea, select {
@@ -8,11 +12,15 @@ input, textarea, select {
  	display: block;
  	width: 100%;
  	margin: auto;
+  margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
  	padding: 1em;
-  padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+  padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
  	box-sizing: border-box;
 
  	background: $form-input-background;
@@ -49,11 +57,15 @@ input[type="checkbox"] {
 form.inline {
   display: inline;
   margin: 0px;
+  margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   padding: 0px;
-  padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+  padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   width: auto;
 
   input[type="submit"] {
@@ -66,7 +78,15 @@ form.inline {
 
     &:not(.button) {
       margin: 0;
+      margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
       padding: 0;
+      padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
       border: none;
       background: transparent;
       color: $purple;
@@ -81,6 +101,10 @@ form.inline {
 
  	border-radius: 0.5em;
  	margin: 0.5em auto;
+  margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
  	padding: 0.75em 1em;
   padding: constant(safe-area-inset-top) 
            constant(safe-area-inset-right) 

--- a/static/css/_forms.scss
+++ b/static/css/_forms.scss
@@ -2,8 +2,8 @@ label {
  	display: block;
  	margin: 2em auto .5em;
   margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
  	font-size: 1.2em;
 }
@@ -12,14 +12,14 @@ input, textarea, select {
  	display: block;
  	width: 100%;
  	margin: auto;
-  margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
  	padding: 1em;
-  padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
  	box-sizing: border-box;
 
@@ -57,14 +57,14 @@ input[type="checkbox"] {
 form.inline {
   display: inline;
   margin: 0px;
-  margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  margin: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
   padding: 0px;
-  padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+  padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
            env(safe-area-inset-left);
   width: auto;
 
@@ -106,10 +106,10 @@ form.inline {
            env(safe-area-inset-bottom)
            env(safe-area-inset-left);
  	padding: 0.75em 1em;
-  padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+  padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
 
  	background: transparent;
  	color: $purple;
@@ -140,10 +140,10 @@ form.new-post {
   .title {
    	margin: 0 auto;
    	padding: 0.75em 0;
-    padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+    padding: env(safe-area-inset-top)
+           env(safe-area-inset-right)
+           env(safe-area-inset-bottom)
+           env(safe-area-inset-left);
 
    	background: none;
    	border: none;

--- a/static/css/_global.scss
+++ b/static/css/_global.scss
@@ -1,5 +1,6 @@
 html, body {
  	margin: 0;
+	@supports(padding: max(0px)) {
  	padding: 0;
 	padding: env(safe-area-inset-right) 
                  env(safe-area-inset-left);
@@ -13,6 +14,7 @@ html, body {
 		background: $lightpurple;
 	}
 }
+ }
 
 a, a:visited {
  	color: $purple;
@@ -59,17 +61,21 @@ small {
 }
 
 /// Main
+@supports(margin: max(0px)) {
 body > main > *, .h-feed > * {
  	margin: 0 20%;
 	margin: env(safe-area-inset-right) 
                 env(safe-area-inset-left);
 }
+ }
 
+@supports(margin: max(0px)) {
 body > main > .h-entry, .h-feed {
 	margin: 0;
 	margin: env(safe-area-inset-right) 
                 env(safe-area-inset-left);
 }
+ }
 
 main {
   h1, h2, h3, h4, h5, h6 {
@@ -190,6 +196,7 @@ p.error {
  	  margin: 20px;
  	}
 
+  @supports(margin: max(0px)) {
  	.cover {
     min-height: 10em;
     background-position: center;
@@ -198,6 +205,7 @@ p.error {
     margin: env(safe-area-inset-right) 
             env(safe-area-inset-left);
   }
+	}
 
   h3 {
    	margin: 0.75em 20px;

--- a/static/css/_global.scss
+++ b/static/css/_global.scss
@@ -1,6 +1,8 @@
 html, body {
  	margin: 0;
  	padding: 0;
+	padding: env(safe-area-inset-right) 
+                 env(safe-area-inset-left);
  	background: $background;
  	color: $black;
  	font-family: $route159;
@@ -59,10 +61,14 @@ small {
 /// Main
 body > main > *, .h-feed > * {
  	margin: 0 20%;
+	margin: env(safe-area-inset-right) 
+                env(safe-area-inset-left);
 }
 
 body > main > .h-entry, .h-feed {
 	margin: 0;
+	margin: env(safe-area-inset-right) 
+                env(safe-area-inset-left);
 }
 
 main {
@@ -160,6 +166,7 @@ p.error {
 /// Cards
 .cards {
  	display: flex;
+	display: -webkit-flex;
  	flex-direction: row;
  	flex-wrap: wrap;
  	padding: 0 5%;
@@ -167,6 +174,7 @@ p.error {
 .card {
  	flex: 1;
  	display: flex;
+	display: -webkit-flex;
  	flex-direction: column;
 
  	min-width: 20em;
@@ -187,10 +195,14 @@ p.error {
     background-position: center;
     background-size: cover;
     margin: 0px;
+    margin: env(safe-area-inset-right) 
+            env(safe-area-inset-left);
   }
 
   h3 {
    	margin: 0.75em 20px;
+	margin: env(safe-area-inset-right) 
+                env(safe-area-inset-left);
    	font-family: $playfair;
    	font-size: 1.75em;
    	font-weight: normal;
@@ -232,11 +244,13 @@ p.error {
 //  Stats
 .stats {
  	display: flex;
+	display: -webkit-flex;
  	justify-content: space-around;
  	margin: 2em;
 
  	> div {
    	display: flex;
+	display: -webkit-flex;
    	flex-direction: column;
    	justify-content: center;
    	align-items: center;
@@ -266,6 +280,7 @@ p.error {
 /// Flex boxes
 .flex {
   display: flex;
+  display: -webkit-flex;
   flex-direction: row;
   align-items: center;
 
@@ -296,6 +311,7 @@ p.error {
 /// Footer
 body > footer {
   display: flex;
+  display: -webkit-flex;
   align-content: center;
   justify-content: space-between;
   background: $lightgray;
@@ -311,6 +327,8 @@ body > footer {
 figure {
   text-align: center;
   margin: 2em;
+  margin: env(safe-area-inset-right) 
+          env(safe-area-inset-left);
   max-width: 100%;
   width: auto;
   height: auto;
@@ -390,6 +408,7 @@ figure {
   margin: auto 20% 2em;
   overflow: auto;
   display: flex;
+  display: -webkit-flex;
 
   a {
     display: inline-block;

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -15,8 +15,6 @@ header {
     transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
-    padding: env(safe-area-inset-top) 
-           env(safe-area-inset-left);
     background: $purple;
     align-self: flex-start;
 
@@ -64,7 +62,7 @@ header {
      	&.title {
      	  margin: 0;
         margin: env(safe-area-inset-right) 
-                 env(safe-area-inset-left);
+                env(safe-area-inset-left);
         text-align: center;
         padding: 0.5em 1em;
         padding: env(safe-area-inset-right) 

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -57,26 +57,18 @@ header {
      	align-self: stretch;
      	margin: 0;
      	padding: 0 2em;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-left) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-right);
      	font-size: 1em;
 
      	i { font-size: 1.2em; }
 
      	&.title {
      	  margin: 0;
-        margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+        margin: env(safe-area-inset-right) 
+                 env(safe-area-inset-left);
         text-align: center;
         padding: 0.5em 1em;
-        padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+        padding: env(safe-area-inset-right) 
+                 env(safe-area-inset-left);
         font-size: 1.75em;
 
         img {
@@ -86,10 +78,8 @@ header {
 
         p {
           margin: 0;
-          margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+          margin: env(safe-area-inset-right) 
+                  env(safe-area-inset-left);
           padding-left: 0.5em;
         }
      	}
@@ -117,9 +107,7 @@ header {
    		transition: all 0.2s ease;
    		margin: 0;
       margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+              env(safe-area-inset-left);
    	}
 
    	.mobile-label {

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -15,10 +15,10 @@ header {
     transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
-    padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+    padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
     background: $purple;
     align-self: flex-start;
 
@@ -32,11 +32,15 @@ header {
      	width: 1.4em;
      	height: 1.4em;
      	margin: 0;
+      margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	padding: 0;
-      padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	color: $lightgray;
      	font-size: 1.33em;
    	}
@@ -63,18 +67,26 @@ header {
      	align-self: stretch;
      	margin: 0;
      	padding: 0 2em;
+      padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
      	font-size: 1em;
 
      	i { font-size: 1.2em; }
 
      	&.title {
      	  margin: 0;
+        margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
         text-align: center;
         padding: 0.5em 1em;
-        padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+        padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
         font-size: 1.75em;
 
         img {
@@ -84,6 +96,10 @@ header {
 
         p {
           margin: 0;
+          margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
           padding-left: 0.5em;
         }
      	}
@@ -110,6 +126,10 @@ header {
  	  i {
    		transition: all 0.2s ease;
    		margin: 0;
+      margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
    	}
 
    	.mobile-label {

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -15,6 +15,10 @@ header {
     transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
+    padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
     background: $purple;
     align-self: flex-start;
 
@@ -29,6 +33,10 @@ header {
      	height: 1.4em;
      	margin: 0;
      	padding: 0;
+      padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
      	color: $lightgray;
      	font-size: 1.33em;
    	}
@@ -63,6 +71,10 @@ header {
      	  margin: 0;
         text-align: center;
         padding: 0.5em 1em;
+        padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
         font-size: 1.75em;
 
         img {
@@ -103,7 +115,6 @@ header {
    	.mobile-label {
    		transition: all 0.2s ease;
    		display: block;
-      display: -webkit-block;
    		position: absolute;
    		left: 50%;
    		transform: translate(-50%, 0);

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -16,8 +16,6 @@ header {
     left: -1em;
     padding: 1em 1em 1em 2em;
     padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
            env(safe-area-inset-left);
     background: $purple;
     align-self: flex-start;
@@ -32,15 +30,7 @@ header {
      	width: 1.4em;
      	height: 1.4em;
      	margin: 0;
-      margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
      	padding: 0;
-      padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
      	color: $lightgray;
      	font-size: 1.33em;
    	}
@@ -68,9 +58,9 @@ header {
      	margin: 0;
      	padding: 0 2em;
       padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
+           env(safe-area-inset-left) 
            env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+           env(safe-area-inset-right);
      	font-size: 1em;
 
      	i { font-size: 1.2em; }

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -61,12 +61,8 @@ header {
 
      	&.title {
      	  margin: 0;
-        margin: env(safe-area-inset-right) 
-                env(safe-area-inset-left);
         text-align: center;
         padding: 0.5em 1em;
-        padding: env(safe-area-inset-right) 
-                 env(safe-area-inset-left);
         font-size: 1.75em;
 
         img {
@@ -76,8 +72,6 @@ header {
 
         p {
           margin: 0;
-          margin: env(safe-area-inset-right) 
-                  env(safe-area-inset-left);
           padding-left: 0.5em;
         }
      	}

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -10,6 +10,7 @@ header {
   nav#menu {
     position: relative;
     display: none;
+    -webkit-appearance: none;
     transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
@@ -19,6 +20,7 @@ header {
     a {
       transform: skewX(15deg);
      	display: flex;
+      display: -webkit-flex;
      	flex-direction: column;
      	align-items: center;
      	justify-content: center;
@@ -33,6 +35,7 @@ header {
 
   nav {
     display: flex;
+    display: -webkit-flex;
    	flex-direction: row;
    	align-items: center;
 

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -106,8 +106,6 @@ header {
  	  i {
    		transition: all 0.2s ease;
    		margin: 0;
-      margin: env(safe-area-inset-top) 
-              env(safe-area-inset-left);
    	}
 
    	.mobile-label {

--- a/static/css/_header.scss
+++ b/static/css/_header.scss
@@ -3,6 +3,7 @@ header {
 
   #content {
     display: flex;
+    display: -webkit-flex;
    	align-content: center;
    	justify-content: space-between;
   }
@@ -48,6 +49,7 @@ header {
     }
     a {
      	display: flex;
+      display: -webkit-flex;
      	align-items: center;
      	position: relative;
      	align-self: stretch;
@@ -101,6 +103,7 @@ header {
    	.mobile-label {
    		transition: all 0.2s ease;
    		display: block;
+      display: -webkit-block;
    		position: absolute;
    		left: 50%;
    		transform: translate(-50%, 0);

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -99,8 +99,6 @@ html {
         > nav hr {
           display: block;
           margin: 0;
-          margin: env(safe-area-inset-right) 
-                  env(safe-area-inset-left);
           width: 100%;
           border: solid $white 0.1rem;
         }
@@ -111,8 +109,6 @@ html {
 
   body > main > * {
     padding: 0 5%;
-    padding: env(safe-area-inset-right) 
-             env(safe-area-inset-left);
   }
   main .article-meta {
     > * {
@@ -122,8 +118,6 @@ html {
     }
     > p {
       margin: 2em 5%;
-      margin: env(safe-area-inset-right) 
-              env(safe-area-inset-left);
       font-size: 0.9em;
     }
     .comments > * { margin: auto 5%; }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -106,21 +106,31 @@ html {
     }
   }
 
+  @supports(padding: max(0px)) {
   body > main > * {
     padding: 0 5%;
+    padding: env(safe-area-inset-right) 
+            env(safe-area-inset-left);
   }
+   }
+  
+  @supports(margin: max(0px)) {
   main .article-meta {
     > * {
       margin: 0 5%;
       margin: env(safe-area-inset-right) 
               env(safe-area-inset-left);
     }
+     }
+    
+    @supports(margin: max(0px)) {
     > p {
       margin: 2em 5%;
       margin: env(safe-area-inset-right) 
               env(safe-area-inset-left);
       font-size: 0.9em;
     }
+     }
     .comments > * { margin: auto 5%; }
     .comments .comment { padding: 2em 0px; }
   }
@@ -133,11 +143,13 @@ html {
     min-height: 80%;
   }
 
+  @supports(margin: max(0px)) {
   .tabs {
     margin: auto 0px 2em;
     margin: env(safe-area-inset-right) 
-           env(safe-area-inset-left);
+            env(safe-area-inset-left);
   }
+   }
 
   .stats { flex-direction: column; }
     body > footer {

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -37,7 +37,6 @@ html {
 
     nav#menu {
       display: inline-flex;
-      display: -webkit-inline-flex;
     }
 
     #content {
@@ -118,6 +117,8 @@ html {
     }
     > p {
       margin: 2em 5%;
+      margin: env(safe-area-inset-right) 
+              env(safe-area-inset-left);
       font-size: 0.9em;
     }
     .comments > * { margin: auto 5%; }
@@ -150,6 +151,6 @@ html {
   .cards {
     margin: 1rem 0 5rem;
     margin: env(safe-area-inset-right) 
-           env(safe-area-inset-left);
+            env(safe-area-inset-left);
   }
 }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -41,6 +41,7 @@ html {
 
     #content {
       display: none;
+      -webkit-appearance: none;
       text-align: center;
     }
   }
@@ -48,6 +49,7 @@ html {
   header:focus-within #content, #content.show {
     position: fixed;
     display: flex;
+    display: -webkit-flex;
     flex-direction: column;
     justify-content: flex-start;
 
@@ -79,6 +81,7 @@ html {
 
       a {
         display: flex;
+        display: -webkit-flex;
         flex-direction: row;
         align-items: center;
         margin: 0;

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -42,6 +42,7 @@ html {
 
     #content {
       display: none;
+      -webkit-appearance: none;
       text-align: center;
     }
   }
@@ -108,6 +109,10 @@ html {
 
   body > main > * {
     padding: 0 5%;
+    padding: constant(safe-area-inset-top) 
+           constant(safe-area-inset-right) 
+           constant(safe-area-inset-bottom) 
+           constant(safe-area-inset-left);
   }
   main .article-meta {
     > * {

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -37,11 +37,11 @@ html {
 
     nav#menu {
       display: inline-flex;
+      display: -webkit-inline-flex;
     }
 
     #content {
       display: none;
-      -webkit-appearance: none;
       text-align: center;
     }
   }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -86,15 +86,7 @@ html {
         flex-direction: row;
         align-items: center;
         margin: 0;
-        margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
         padding: 1rem 1.5rem;
-        padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
         color: $white;
         font-size: 1.4em;
         font-weight: 300;
@@ -107,10 +99,8 @@ html {
         > nav hr {
           display: block;
           margin: 0;
-          margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+          margin: env(safe-area-inset-right) 
+                  env(safe-area-inset-left);
           width: 100%;
           border: solid $white 0.1rem;
         }
@@ -121,25 +111,19 @@ html {
 
   body > main > * {
     padding: 0 5%;
-    padding: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+    padding: env(safe-area-inset-right) 
+             env(safe-area-inset-left);
   }
   main .article-meta {
     > * {
       margin: 0 5%;
-      margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right) 
+              env(safe-area-inset-left);
     }
     > p {
       margin: 2em 5%;
-      margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
-           env(safe-area-inset-left);
+      margin: env(safe-area-inset-right) 
+              env(safe-area-inset-left);
       font-size: 0.9em;
     }
     .comments > * { margin: auto 5%; }
@@ -156,9 +140,7 @@ html {
 
   .tabs {
     margin: auto 0px 2em;
-    margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+    margin: env(safe-area-inset-right) 
            env(safe-area-inset-left);
   }
 
@@ -173,9 +155,7 @@ html {
 
   .cards {
     margin: 1rem 0 5rem;
-    margin: env(safe-area-inset-top) 
-           env(safe-area-inset-right) 
-           env(safe-area-inset-bottom) 
+    margin: env(safe-area-inset-right) 
            env(safe-area-inset-left);
   }
 }

--- a/static/css/main.scss
+++ b/static/css/main.scss
@@ -86,7 +86,15 @@ html {
         flex-direction: row;
         align-items: center;
         margin: 0;
+        margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
         padding: 1rem 1.5rem;
+        padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
         color: $white;
         font-size: 1.4em;
         font-weight: 300;
@@ -99,6 +107,10 @@ html {
         > nav hr {
           display: block;
           margin: 0;
+          margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
           width: 100%;
           border: solid $white 0.1rem;
         }
@@ -109,17 +121,25 @@ html {
 
   body > main > * {
     padding: 0 5%;
-    padding: constant(safe-area-inset-top) 
-           constant(safe-area-inset-right) 
-           constant(safe-area-inset-bottom) 
-           constant(safe-area-inset-left);
+    padding: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   }
   main .article-meta {
     > * {
       margin: 0 5%;
+      margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
     }
     > p {
       margin: 2em 5%;
+      margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
       font-size: 0.9em;
     }
     .comments > * { margin: auto 5%; }
@@ -136,6 +156,10 @@ html {
 
   .tabs {
     margin: auto 0px 2em;
+    margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   }
 
   .stats { flex-direction: column; }
@@ -149,5 +173,9 @@ html {
 
   .cards {
     margin: 1rem 0 5rem;
+    margin: env(safe-area-inset-top) 
+           env(safe-area-inset-right) 
+           env(safe-area-inset-bottom) 
+           env(safe-area-inset-left);
   }
 }

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -8,7 +8,7 @@
     <head>
         <meta charset="utf-8" />
         <title>@title ⋅ @i18n!(ctx.1, "Plume")</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <link rel="stylesheet" href="@uri!(plume_static_files: file = "css/main.css", _build_id = CACHE_NAME)" />
         <link rel="stylesheet" href="@uri!(plume_static_files: file = "css/feather.css", _build_id = CACHE_NAME)" />
         <link rel="manifest" href="@uri!(instance::web_manifest)" />


### PR DESCRIPTION
This is just a small PR with _adds basic iPhone X support_ to the viewport tag and also adds CSS rules to forms for them to stay inside the iPhoxe X/R ''safe area'' space and not feel cut out.

<img width="957" alt="safe-areas-webkit-ios" src="https://user-images.githubusercontent.com/45913977/56860508-a4f4de00-6997-11e9-93a8-a86514c39ead.png">

Other platforms and browsers are not affected by this change in any way, as all of these rules are only Apple specific.

It should achieve that no text, or form would be cut by the notch.

Right now article content on iPhone X is displayed like this:
<img width="846" alt="Screenshot 2019-04-28 at 22 02 34" src="https://user-images.githubusercontent.com/45913977/56870432-85010100-6a0f-11e9-8274-31dd0103a9c5.png">

That is less than ideal. The PR works on resolving this issue.
