### PR TITLE
reduce reqwest timeout to 5s

### DIFF
--- a/plume-common/src/activity_pub/inbox.rs
+++ b/plume-common/src/activity_pub/inbox.rs
@@ -279,7 +279,10 @@ pub trait FromId<C>: Sized {
 
     /// Dereferences an ID
     fn deref(id: &str) -> Result<Self::Object, (Option<serde_json::Value>, Self::Error)> {
-        reqwest::Client::new()
+        reqwest::ClientBuilder::new()
+            .connect_timeout(Some(std::time::Duration::from_secs(5)))
+            .build()
+            .map_err(|_| (None, InboxError::DerefError.into()))?
             .get(id)
             .header(
                 ACCEPT,

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -23,7 +23,7 @@ use plume_common::activity_pub::{
 use plume_common::utils;
 use reqwest::{
     header::{HeaderValue, ACCEPT},
-    Client,
+    ClientBuilder,
 };
 use rocket::{
     outcome::IntoOutcome,
@@ -267,7 +267,9 @@ impl User {
     }
 
     fn fetch(url: &str) -> Result<CustomPerson> {
-        let mut res = Client::new()
+        let mut res = ClientBuilder::new()
+            .connect_timeout(Some(std::time::Duration::from_secs(5)))
+            .build()?
             .get(url)
             .header(
                 ACCEPT,
@@ -369,7 +371,9 @@ impl User {
     }
 
     pub fn fetch_outbox<T: Activity>(&self) -> Result<Vec<T>> {
-        let mut res = Client::new()
+        let mut res = ClientBuilder::new()
+            .connect_timeout(Some(std::time::Duration::from_secs(5)))
+            .build()?
             .get(&self.outbox_url[..])
             .header(
                 ACCEPT,
@@ -392,7 +396,9 @@ impl User {
     }
 
     pub fn fetch_followers_ids(&self) -> Result<Vec<String>> {
-        let mut res = Client::new()
+        let mut res = ClientBuilder::new()
+            .connect_timeout(Some(std::time::Duration::from_secs(5)))
+            .build()?
             .get(&self.followers_endpoint[..])
             .header(
                 ACCEPT,


### PR DESCRIPTION
Current timeout is 30s, this add a second kind of timeout : if connection to remote can't be established in 5s, the remote is considered down, so that a thread don't stall for too long for no reason (and also make some unit test much faster to run)