### PR TITLE
feature: custom domains using Fairings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,7 @@ dependencies = [
  "plume-api 0.3.0",
  "plume-common 0.3.0",
  "plume-models 0.3.0",
+ "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_csrf 0.1.0 (git+https://github.com/fdb-hiroshima/rocket_csrf?rev=4a72ea2ec716cb0b26188fb00bccf2ef7d1e031c)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ heck = "0.3.0"
 lettre = { git = "https://github.com/lettre/lettre", rev = "c988b1760ad8179d9e7f3fb8594d2b86cf2a0a49" }
 lettre_email = { git = "https://github.com/lettre/lettre", rev = "c988b1760ad8179d9e7f3fb8594d2b86cf2a0a49" }
 num_cpus = "1.10"
+reqwest = "0.9"
 rocket = "0.4.0"
 rocket_contrib = { version = "0.4.0", features = ["json"] }
 rocket_i18n = { git = "https://github.com/Plume-org/rocket_i18n", rev = "e922afa7c366038b3433278c03b1456b346074f2" }

--- a/migrations/postgres/2019-05-22-124143_add_custom_domains/down.sql
+++ b/migrations/postgres/2019-05-22-124143_add_custom_domains/down.sql
@@ -1,0 +1,2 @@
+-- undo the adding of custom_domain column to blogs table.
+ALTER TABLE blogs DROP COLUMN custom_domain;

--- a/migrations/postgres/2019-05-22-124143_add_custom_domains/up.sql
+++ b/migrations/postgres/2019-05-22-124143_add_custom_domains/up.sql
@@ -1,0 +1,2 @@
+--- Adding custom domain to Blog as an optional field
+ALTER TABLE blogs ADD COLUMN custom_domain VARCHAR DEFAULT NULL UNIQUE;

--- a/migrations/sqlite/2019-05-22-124153_add_custom_domains/down.sql
+++ b/migrations/sqlite/2019-05-22-124153_add_custom_domains/down.sql
@@ -1,0 +1,56 @@
+-- undo the adding of "custom_domain" to blogs
+CREATE TABLE IF NOT EXISTS "blogs_drop_custom_domain" (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  actor_id VARCHAR NOT NULL,
+  title VARCHAR NOT NULL,
+  summary TEXT NOT NULL DEFAULT '',
+  outbox_url VARCHAR NOT NULL UNIQUE,
+  inbox_url VARCHAR NOT NULL UNIQUE,
+  instance_id INTEGER REFERENCES instances(id) ON DELETE CASCADE NOT NULL,
+  creation_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ap_url text not null default '' UNIQUE,
+  private_key TEXT,
+  public_key TEXT NOT NULL DEFAULT '',
+  fqn TEXT NOT NULL DEFAULT '',
+  summary_html TEXT NOT NULL DEFAULT '',
+  icon_id INTEGER REFERENCES medias(id) ON DELETE SET NULL DEFAULT NULL,
+  banner_id INTEGER REFERENCES medias(id) ON DELETE SET NULL DEFAULT NULL,
+  CONSTRAINT blog_unique UNIQUE (actor_id, instance_id)
+);
+
+INSERT INTO blogs_drop_custom_domain (
+  id,
+  actor_id,
+  title,
+  summary,
+  outbox_url,
+  inbox_url,
+  instance_id,
+  creation_date,
+  ap_url,
+  private_key,
+  public_key,
+  fqn,
+  summary_html,
+  icon_id,
+  banner_id
+) SELECT
+  id,
+  actor_id,
+  title,
+  summary,
+  outbox_url,
+  inbox_url,
+  instance_id,
+  creation_date,
+  ap_url,
+  private_key,
+  public_key,
+  fqn,
+  summary_html,
+  icon_id,
+  banner_id
+FROM blogs;
+
+DROP TABLE blogs;
+ALTER TABLE "blogs_drop_custom_domain" RENAME to blogs;

--- a/migrations/sqlite/2019-05-22-124153_add_custom_domains/up.sql
+++ b/migrations/sqlite/2019-05-22-124153_add_custom_domains/up.sql
@@ -1,0 +1,57 @@
+-- add custom_domain to blogs
+CREATE TABLE IF NOT EXISTS "blogs_add_custom_domain" (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  actor_id VARCHAR NOT NULL,
+  title VARCHAR NOT NULL,
+  summary TEXT NOT NULL DEFAULT '',
+  outbox_url VARCHAR NOT NULL UNIQUE,
+  inbox_url VARCHAR NOT NULL UNIQUE,
+  instance_id INTEGER REFERENCES instances(id) ON DELETE CASCADE NOT NULL,
+  creation_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ap_url text not null default '' UNIQUE,
+  private_key TEXT,
+  public_key TEXT NOT NULL DEFAULT '',
+  fqn TEXT NOT NULL DEFAULT '',
+  summary_html TEXT NOT NULL DEFAULT '',
+  icon_id INTEGER REFERENCES medias(id) ON DELETE SET NULL DEFAULT NULL,
+  banner_id INTEGER REFERENCES medias(id) ON DELETE SET NULL DEFAULT NULL,
+  custom_domain text default NULL UNIQUE,
+  CONSTRAINT blog_unique UNIQUE (actor_id, instance_id)
+);
+
+INSERT INTO blogs_add_custom_domain (
+  id,
+  actor_id,
+  title,
+  summary,
+  outbox_url,
+  inbox_url,
+  instance_id,
+  creation_date,
+  ap_url,
+  private_key,
+  public_key,
+  fqn,
+  summary_html,
+  icon_id,
+  banner_id
+) SELECT
+  id,
+  actor_id,
+  title,
+  summary,
+  outbox_url,
+  inbox_url,
+  instance_id,
+  creation_date,
+  ap_url,
+  private_key,
+  public_key,
+  fqn,
+  summary_html,
+  icon_id,
+  banner_id
+FROM blogs;
+
+DROP TABLE blogs;
+ALTER TABLE "blogs_add_custom_domain" RENAME to blogs;

--- a/plume-models/Cargo.toml
+++ b/plume-models/Cargo.toml
@@ -25,7 +25,6 @@ tantivy = "0.10.1"
 url = "2.1"
 webfinger = "0.4.1"
 whatlang = "0.7.1"
-shrinkwraprs = "0.2.1"
 diesel-derive-newtype = "0.1.2"
 
 [dependencies.chrono]

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -335,7 +335,7 @@ impl Blog {
                 .unwrap_or_else(|| Host::new(format!(
                     "{}/~/{}",
                     Instance::get_local().unwrap().public_domain,
-                    self.title
+                    self.fqn,
                 )))
         )
     }

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -81,7 +81,7 @@ pub struct NewBlog {
     pub summary_html: SafeString,
     pub icon_id: Option<i32>,
     pub banner_id: Option<i32>,
-    pub custom_domain: Option<String>,
+    pub custom_domain: Option<Host>,
 }
 
 const BLOG_PREFIX: &str = "~";
@@ -310,6 +310,15 @@ impl Blog {
             .execute(conn)
             .map(|_| ())
             .map_err(Error::from)
+    }
+
+    pub fn list_custom_domains(conn: &Connection) -> Result<Vec<String>> {
+        blogs::table
+            .filter(blogs::custom_domain.is_not_null())
+            .select(blogs::custom_domain)
+            .load::<Option<String>>(conn)
+            .map_err(Error::from)
+            .map(|res| res.into_iter().map(|s| s.unwrap()).collect::<Vec<_>>())
     }
 }
 

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -25,6 +25,7 @@ use posts::Post;
 use safe_string::SafeString;
 use schema::blogs;
 use search::Searcher;
+use std::fmt::{self, Display};
 use users::User;
 use {Connection, Error, PlumeRocket, Result};
 
@@ -36,6 +37,12 @@ pub struct Host(String);
 impl Host {
     pub fn new(host: impl ToString) -> Host {
         Host(host.to_string())
+    }
+}
+
+impl Display for Host {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -195,6 +195,23 @@ impl Blog {
         }
     }
 
+    pub fn find_by_host(c: &PlumeRocket, host: Host) -> Result<Blog> {
+        let from_db = blogs::table
+            .filter(blogs::custom_domain.eq(host))
+            .limit(1)
+            .load::<Blog>(&*c.conn)?
+            .into_iter()
+            .next();
+        if let Some(from_db) = from_db {
+            Ok(from_db)
+        } else {
+            // we should never get here, because
+            // a) load::<Blog>()? should return early if it fails
+            // b) this function is only called after a Request::guard::<Host>()
+            Err(Error::NotFound)
+        }
+    }
+
     fn fetch_from_webfinger(c: &PlumeRocket, acct: &str) -> Result<Blog> {
         resolve_with_prefix(Prefix::Group, acct.to_owned(), true)?
             .links

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -1,6 +1,6 @@
 use activitypub::{actor::Group, collection::OrderedCollection, object::Image, CustomObject};
 use chrono::NaiveDateTime;
-use diesel::{self, ExpressionMethods, QueryDsl, QueryResult, RunQueryDsl, SaveChangesDsl};
+use diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl, SaveChangesDsl};
 use openssl::{
     hash::MessageDigest,
     pkey::{PKey, Private},
@@ -195,10 +195,11 @@ impl Blog {
         }
     }
 
-    pub fn find_by_host(c: &PlumeRocket, host: Host) -> QueryResult<Blog> {
+    pub fn find_by_host(c: &PlumeRocket, host: Host) -> Result<Blog> {
         blogs::table
             .filter(blogs::custom_domain.eq(host))
             .first::<Blog>(&*c.conn)
+            .map_err(|_| Error::NotFound)
     }
 
     fn fetch_from_webfinger(c: &PlumeRocket, acct: &str) -> Result<Blog> {

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -8,8 +8,9 @@ use openssl::{
     sign::{Signer, Verifier},
 };
 use rocket::{
+    http::RawStr,
     outcome::IntoOutcome,
-    request::{self, FromRequest, Request},
+    request::{self, FromFormValue, FromRequest, Request},
 };
 use serde_json;
 use url::Url;
@@ -68,6 +69,15 @@ impl<'a, 'r> FromRequest<'a, 'r> for Host {
                 }
             })
             .or_forward(())
+    }
+}
+
+impl<'v> FromFormValue<'v> for Host {
+    type Error = &'v RawStr;
+
+    fn from_form_value(form_value: &'v RawStr) -> std::result::Result<Host, &'v RawStr> {
+        let val = String::from_form_value(form_value)?;
+        Ok(Host::new(&val))
     }
 }
 

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -44,6 +44,7 @@ pub struct Blog {
     pub summary_html: SafeString,
     pub icon_id: Option<i32>,
     pub banner_id: Option<i32>,
+    pub custom_domain: Option<String>,
 }
 
 #[derive(Default, Insertable)]
@@ -61,6 +62,7 @@ pub struct NewBlog {
     pub summary_html: SafeString,
     pub icon_id: Option<i32>,
     pub banner_id: Option<i32>,
+    pub custom_domain: Option<String>,
 }
 
 const BLOG_PREFIX: &str = "~";
@@ -392,6 +394,7 @@ impl FromId<PlumeRocket> for Blog {
                         .summary_string()
                         .unwrap_or_default(),
                 ),
+                custom_domain: None,
             },
         )
     }

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -202,14 +202,7 @@ impl Blog {
             .load::<Blog>(&*c.conn)?
             .into_iter()
             .next();
-        if let Some(from_db) = from_db {
-            Ok(from_db)
-        } else {
-            // we should never get here, because
-            // a) load::<Blog>()? should return early if it fails
-            // b) this function is only called after a Request::guard::<Host>()
-            Err(Error::NotFound)
-        }
+        from_db.ok_or(Error::NotFound)
     }
 
     fn fetch_from_webfinger(c: &PlumeRocket, acct: &str) -> Result<Blog> {

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -1,6 +1,6 @@
 use activitypub::{actor::Group, collection::OrderedCollection, object::Image, CustomObject};
 use chrono::NaiveDateTime;
-use diesel::{self, ExpressionMethods, QueryDsl, RunQueryDsl, SaveChangesDsl};
+use diesel::{self, ExpressionMethods, QueryDsl, QueryResult, RunQueryDsl, SaveChangesDsl};
 use openssl::{
     hash::MessageDigest,
     pkey::{PKey, Private},
@@ -195,14 +195,10 @@ impl Blog {
         }
     }
 
-    pub fn find_by_host(c: &PlumeRocket, host: Host) -> Result<Blog> {
-        let from_db = blogs::table
+    pub fn find_by_host(c: &PlumeRocket, host: Host) -> QueryResult<Blog> {
+        blogs::table
             .filter(blogs::custom_domain.eq(host))
-            .limit(1)
-            .load::<Blog>(&*c.conn)?
-            .into_iter()
-            .next();
-        from_db.ok_or(Error::NotFound)
+            .first::<Blog>(&*c.conn)
     }
 
     fn fetch_from_webfinger(c: &PlumeRocket, acct: &str) -> Result<Blog> {

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -530,6 +530,7 @@ impl NewBlog {
         title: String,
         summary: String,
         instance_id: i32,
+        custom_domain: Option<Host>,
     ) -> Result<NewBlog> {
         let (pub_key, priv_key) = sign::gen_keypair();
         Ok(NewBlog {
@@ -539,6 +540,7 @@ impl NewBlog {
             instance_id,
             public_key: String::from_utf8(pub_key).or(Err(Error::Signature))?,
             private_key: Some(String::from_utf8(priv_key).or(Err(Error::Signature))?),
+            custom_domain,
             ..NewBlog::default()
         })
     }
@@ -566,6 +568,7 @@ pub(crate) mod tests {
                 "Blog name".to_owned(),
                 "This is a small blog".to_owned(),
                 Instance::get_local().unwrap().id,
+                None,
             )
             .unwrap(),
         )
@@ -577,6 +580,7 @@ pub(crate) mod tests {
                 "My blog".to_owned(),
                 "Welcome to my blog".to_owned(),
                 Instance::get_local().unwrap().id,
+                Some(Host::new("blog.myname.me")),
             )
             .unwrap(),
         )
@@ -588,6 +592,7 @@ pub(crate) mod tests {
                 "Why I like Plume".to_owned(),
                 "In this blog I will explay you why I like Plume so much".to_owned(),
                 Instance::get_local().unwrap().id,
+                None,
             )
             .unwrap(),
         )
@@ -648,6 +653,7 @@ pub(crate) mod tests {
                     "Some name".to_owned(),
                     "This is some blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    Some(Host::new("some.blog.com")),
                 )
                 .unwrap(),
             )
@@ -676,6 +682,7 @@ pub(crate) mod tests {
                     "Some name".to_owned(),
                     "This is some blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    None,
                 )
                 .unwrap(),
             )
@@ -687,6 +694,7 @@ pub(crate) mod tests {
                     "Blog".to_owned(),
                     "I've named my blog Blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    Some(Host::new("named.example.blog")),
                 )
                 .unwrap(),
             )
@@ -779,6 +787,7 @@ pub(crate) mod tests {
                     "Some name".to_owned(),
                     "This is some blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    None,
                 )
                 .unwrap(),
             )
@@ -803,6 +812,7 @@ pub(crate) mod tests {
                     "Some name".to_owned(),
                     "This is some blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    Some(Host::new("some.blog.com")),
                 )
                 .unwrap(),
             )
@@ -841,6 +851,7 @@ pub(crate) mod tests {
                     "Some name".to_owned(),
                     "This is some blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    None,
                 )
                 .unwrap(),
             )
@@ -852,6 +863,7 @@ pub(crate) mod tests {
                     "Blog".to_owned(),
                     "I've named my blog Blog".to_owned(),
                     Instance::get_local().unwrap().id,
+                    Some(Host::new("my.blog.com")),
                 )
                 .unwrap(),
             )

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -325,7 +325,7 @@ impl Blog {
             .select(blogs::custom_domain)
             .load::<Option<String>>(conn)
             .map_err(Error::from)
-            .map(|res| res.into_iter().map(|s| s.unwrap()).collect::<Vec<_>>())
+            .map(|res| res.into_iter().map(Option::unwrap).collect::<Vec<_>>())
     }
 }
 

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -327,6 +327,19 @@ impl Blog {
         })
     }
 
+    pub fn url(&self) -> String {
+        format!(
+            "https://{}",
+            self.custom_domain
+                .clone()
+                .unwrap_or_else(|| Host::new(format!(
+                    "{}/~/{}",
+                    Instance::get_local().unwrap().public_domain,
+                    self.title
+                )))
+        )
+    }
+
     pub fn icon_url(&self, conn: &Connection) -> String {
         self.icon_id
             .and_then(|id| Media::get(conn, id).and_then(|m| m.url()).ok())

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -26,19 +26,28 @@ use posts::Post;
 use safe_string::SafeString;
 use schema::blogs;
 use search::Searcher;
+use std::default::Default;
 use std::fmt::{self, Display};
+use std::ops::Deref;
 use std::sync::RwLock;
 use users::User;
 use {Connection, Error, PlumeRocket, Result};
 
 pub type CustomGroup = CustomObject<ApSignature, Group>;
 
-#[derive(Clone, Debug, PartialEq, DieselNewType, Shrinkwrap)]
+#[derive(Clone, Debug, PartialEq, DieselNewType)]
 pub struct Host(String);
 
 impl Host {
     pub fn new(host: impl ToString) -> Host {
         Host(host.to_string())
+    }
+}
+
+impl Deref for Host {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
     }
 }
 

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -32,7 +32,7 @@ use {Connection, Error, PlumeRocket, Result};
 
 pub type CustomGroup = CustomObject<ApSignature, Group>;
 
-#[derive(Clone, Debug, DieselNewType, Shrinkwrap)]
+#[derive(Clone, Debug, PartialEq, DieselNewType, Shrinkwrap)]
 pub struct Host(String);
 
 impl Host {

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -10,6 +10,8 @@ extern crate bcrypt;
 extern crate chrono;
 #[macro_use]
 extern crate diesel;
+#[macro_use]
+extern crate diesel_derive_newtype;
 extern crate guid_create;
 extern crate heck;
 extern crate itertools;
@@ -30,6 +32,8 @@ extern crate serde;
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
+#[macro_use]
+extern crate shrinkwraprs;
 #[macro_use]
 extern crate tantivy;
 extern crate url;

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -33,8 +33,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
-extern crate shrinkwraprs;
-#[macro_use]
 extern crate tantivy;
 extern crate url;
 extern crate webfinger;

--- a/plume-models/src/schema.rs
+++ b/plume-models/src/schema.rs
@@ -1,17 +1,17 @@
 table! {
     api_tokens (id) {
-        id -> Int4,
+        id -> Integer,
         creation_date -> Timestamp,
         value -> Text,
         scopes -> Text,
-        app_id -> Int4,
-        user_id -> Int4,
+        app_id -> Integer,
+        user_id -> Integer,
     }
 }
 
 table! {
     apps (id) {
-        id -> Int4,
+        id -> Integer,
         name -> Text,
         client_id -> Text,
         client_secret -> Text,
@@ -23,42 +23,51 @@ table! {
 
 table! {
     blog_authors (id) {
-        id -> Int4,
-        blog_id -> Int4,
-        author_id -> Int4,
+        id -> Integer,
+        blog_id -> Integer,
+        author_id -> Integer,
         is_owner -> Bool,
     }
 }
 
 table! {
     blogs (id) {
-        id -> Int4,
-        actor_id -> Varchar,
-        title -> Varchar,
+        id -> Integer,
+        actor_id -> Text,
+        title -> Text,
         summary -> Text,
-        outbox_url -> Varchar,
-        inbox_url -> Varchar,
-        instance_id -> Int4,
+        outbox_url -> Text,
+        inbox_url -> Text,
+        instance_id -> Integer,
         creation_date -> Timestamp,
         ap_url -> Text,
         private_key -> Nullable<Text>,
         public_key -> Text,
         fqn -> Text,
         summary_html -> Text,
-        icon_id -> Nullable<Int4>,
-        banner_id -> Nullable<Int4>,
+        icon_id -> Nullable<Integer>,
+        banner_id -> Nullable<Integer>,
+        custom_domain -> Nullable<Text>,
+    }
+}
+
+table! {
+    comment_seers (id) {
+        id -> Integer,
+        comment_id -> Integer,
+        user_id -> Integer,
     }
 }
 
 table! {
     comments (id) {
-        id -> Int4,
+        id -> Integer,
         content -> Text,
-        in_response_to_id -> Nullable<Int4>,
-        post_id -> Int4,
-        author_id -> Int4,
+        in_response_to_id -> Nullable<Integer>,
+        post_id -> Integer,
+        author_id -> Integer,
         creation_date -> Timestamp,
-        ap_url -> Nullable<Varchar>,
+        ap_url -> Nullable<Text>,
         sensitive -> Bool,
         spoiler_text -> Text,
         public_visibility -> Bool,
@@ -66,27 +75,19 @@ table! {
 }
 
 table! {
-    comment_seers (id) {
-        id -> Int4,
-        comment_id -> Int4,
-        user_id -> Int4,
-    }
-}
-
-table! {
     follows (id) {
-        id -> Int4,
-        follower_id -> Int4,
-        following_id -> Int4,
+        id -> Integer,
+        follower_id -> Integer,
+        following_id -> Integer,
         ap_url -> Text,
     }
 }
 
 table! {
     instances (id) {
-        id -> Int4,
-        public_domain -> Varchar,
-        name -> Varchar,
+        id -> Integer,
+        public_domain -> Text,
+        name -> Text,
         local -> Bool,
         blocked -> Bool,
         creation_date -> Timestamp,
@@ -94,50 +95,50 @@ table! {
         short_description -> Text,
         long_description -> Text,
         default_license -> Text,
-        long_description_html -> Varchar,
-        short_description_html -> Varchar,
+        long_description_html -> Text,
+        short_description_html -> Text,
     }
 }
 
 table! {
     likes (id) {
-        id -> Int4,
-        user_id -> Int4,
-        post_id -> Int4,
+        id -> Integer,
+        user_id -> Integer,
+        post_id -> Integer,
         creation_date -> Timestamp,
-        ap_url -> Varchar,
+        ap_url -> Text,
     }
 }
 
 table! {
     medias (id) {
-        id -> Int4,
+        id -> Integer,
         file_path -> Text,
         alt_text -> Text,
         is_remote -> Bool,
         remote_url -> Nullable<Text>,
         sensitive -> Bool,
         content_warning -> Nullable<Text>,
-        owner_id -> Int4,
+        owner_id -> Integer,
     }
 }
 
 table! {
     mentions (id) {
-        id -> Int4,
-        mentioned_id -> Int4,
-        post_id -> Nullable<Int4>,
-        comment_id -> Nullable<Int4>,
+        id -> Integer,
+        mentioned_id -> Integer,
+        post_id -> Nullable<Integer>,
+        comment_id -> Nullable<Integer>,
     }
 }
 
 table! {
     notifications (id) {
-        id -> Int4,
-        user_id -> Int4,
+        id -> Integer,
+        user_id -> Integer,
         creation_date -> Timestamp,
-        kind -> Varchar,
-        object_id -> Int4,
+        kind -> Text,
+        object_id -> Integer,
     }
 }
 
@@ -152,67 +153,67 @@ table! {
 
 table! {
     post_authors (id) {
-        id -> Int4,
-        post_id -> Int4,
-        author_id -> Int4,
+        id -> Integer,
+        post_id -> Integer,
+        author_id -> Integer,
     }
 }
 
 table! {
     posts (id) {
-        id -> Int4,
-        blog_id -> Int4,
-        slug -> Varchar,
-        title -> Varchar,
+        id -> Integer,
+        blog_id -> Integer,
+        slug -> Text,
+        title -> Text,
         content -> Text,
         published -> Bool,
-        license -> Varchar,
+        license -> Text,
         creation_date -> Timestamp,
-        ap_url -> Varchar,
+        ap_url -> Text,
         subtitle -> Text,
         source -> Text,
-        cover_id -> Nullable<Int4>,
+        cover_id -> Nullable<Integer>,
     }
 }
 
 table! {
     reshares (id) {
-        id -> Int4,
-        user_id -> Int4,
-        post_id -> Int4,
-        ap_url -> Varchar,
+        id -> Integer,
+        user_id -> Integer,
+        post_id -> Integer,
+        ap_url -> Text,
         creation_date -> Timestamp,
     }
 }
 
 table! {
     tags (id) {
-        id -> Int4,
+        id -> Integer,
         tag -> Text,
         is_hashtag -> Bool,
-        post_id -> Int4,
+        post_id -> Integer,
     }
 }
 
 table! {
     users (id) {
-        id -> Int4,
-        username -> Varchar,
-        display_name -> Varchar,
-        outbox_url -> Varchar,
-        inbox_url -> Varchar,
+        id -> Integer,
+        username -> Text,
+        display_name -> Text,
+        outbox_url -> Text,
+        inbox_url -> Text,
         is_admin -> Bool,
         summary -> Text,
         email -> Nullable<Text>,
         hashed_password -> Nullable<Text>,
-        instance_id -> Int4,
+        instance_id -> Integer,
         creation_date -> Timestamp,
         ap_url -> Text,
         private_key -> Nullable<Text>,
         public_key -> Text,
-        shared_inbox_url -> Nullable<Varchar>,
-        followers_endpoint -> Varchar,
-        avatar_id -> Nullable<Int4>,
+        shared_inbox_url -> Nullable<Text>,
+        followers_endpoint -> Text,
+        avatar_id -> Nullable<Integer>,
         last_fetched_date -> Timestamp,
         fqn -> Text,
         summary_html -> Text,
@@ -248,8 +249,8 @@ allow_tables_to_appear_in_same_query!(
     apps,
     blog_authors,
     blogs,
-    comments,
     comment_seers,
+    comments,
     follows,
     instances,
     likes,

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -36,39 +36,39 @@ msgstr ""
 msgid "{0}'s avatar"
 msgstr ""
 
-# src/routes/blogs.rs:64
+# src/routes/blogs.rs:84
 msgid "To create a new blog, you need to be logged in"
 msgstr ""
 
-# src/routes/blogs.rs:106
+# src/routes/blogs.rs:126
 msgid "A blog with the same name already exists."
 msgstr ""
 
-# src/routes/blogs.rs:141
+# src/routes/blogs.rs:161
 msgid "Your blog was successfully created!"
 msgstr ""
 
-# src/routes/blogs.rs:163
+# src/routes/blogs.rs:183
 msgid "Your blog was deleted."
 msgstr ""
 
-# src/routes/blogs.rs:170
+# src/routes/blogs.rs:190
 msgid "You are not allowed to delete this blog."
 msgstr ""
 
-# src/routes/blogs.rs:218
+# src/routes/blogs.rs:238
 msgid "You are not allowed to edit this blog."
 msgstr ""
 
-# src/routes/blogs.rs:263
+# src/routes/blogs.rs:283
 msgid "You can't use this media as a blog icon."
 msgstr ""
 
-# src/routes/blogs.rs:281
+# src/routes/blogs.rs:301
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
-# src/routes/blogs.rs:314
+# src/routes/blogs.rs:334
 msgid "Your blog information have been updated."
 msgstr ""
 

--- a/po/plume/plume.pot
+++ b/po/plume/plume.pot
@@ -36,39 +36,39 @@ msgstr ""
 msgid "{0}'s avatar"
 msgstr ""
 
-# src/routes/blogs.rs:84
+# src/routes/blogs.rs:96
 msgid "To create a new blog, you need to be logged in"
 msgstr ""
 
-# src/routes/blogs.rs:126
+# src/routes/blogs.rs:138
 msgid "A blog with the same name already exists."
 msgstr ""
 
-# src/routes/blogs.rs:161
+# src/routes/blogs.rs:173
 msgid "Your blog was successfully created!"
 msgstr ""
 
-# src/routes/blogs.rs:183
+# src/routes/blogs.rs:195
 msgid "Your blog was deleted."
 msgstr ""
 
-# src/routes/blogs.rs:190
+# src/routes/blogs.rs:202
 msgid "You are not allowed to delete this blog."
 msgstr ""
 
-# src/routes/blogs.rs:238
+# src/routes/blogs.rs:250
 msgid "You are not allowed to edit this blog."
 msgstr ""
 
-# src/routes/blogs.rs:283
+# src/routes/blogs.rs:295
 msgid "You can't use this media as a blog icon."
 msgstr ""
 
-# src/routes/blogs.rs:301
+# src/routes/blogs.rs:313
 msgid "You can't use this media as a blog banner."
 msgstr ""
 
-# src/routes/blogs.rs:334
+# src/routes/blogs.rs:346
 msgid "Your blog information have been updated."
 msgstr ""
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ extern crate webfinger;
 use clap::App;
 use diesel::r2d2::ConnectionManager;
 use plume_models::{
+    blogs::Blog,
     blogs::Host,
     db_conn::{DbPool, PragmaForeignKey},
     instance::Instance,
@@ -89,6 +90,7 @@ fn init_pool() -> Option<DbPool> {
         .build(manager)
         .ok()?;
     Instance::cache_local(&pool.get().unwrap());
+    Blog::cache_custom_domains(&pool.get().unwrap());
     Some(pool)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,14 @@ Then try to restart Plume
     let valid_domains: HashMap<String, Instant> = HashMap::new();
     let rocket = rocket::custom(CONFIG.rocket.clone().unwrap())
         .mount(
+            "/custom_domains/domain_validation/",
+            routes![routes::blogs::custom::domain_validation,],
+        )
+        .mount(
+            "/domain_validation/",
+            routes![routes::blogs::domain_validation,],
+        )
+        .mount(
             "/custom_domains/",
             routes![
                 routes::blogs::custom::details,
@@ -208,10 +216,6 @@ Then try to restart Plume
                 routes::blogs::custom::activity_details,
                 routes::search::custom::search,
             ],
-        )
-        .mount(
-            "/domain_validation/",
-            routes![routes::blogs::domain_validation,],
         )
         .mount(
             "/",

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ Then try to restart Plume
             routes![
                 routes::blogs::custom_details,
                 routes::blogs::custom_activity_details,
+                routes::search::custom_search,
             ],
         )
         .mount(

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,14 @@ Then try to restart Plume
 
     let custom_domain_fairing = AdHoc::on_request("Custom Blog Domains", |req, _data| {
         let host = req.guard::<Host>();
-        if host.is_success() {
+        if host.is_success()
+            && req
+                .uri()
+                .segments()
+                .next()
+                .map(|path| path != "static" && path != "api")
+                .unwrap_or(true)
+        {
             let rewrite_uri = format!("/custom_domains/{}/{}", host.unwrap(), req.uri());
             let uri = Origin::parse_owned(rewrite_uri).unwrap();
             let uri = uri.to_normalized().into_owned();

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,13 @@ Then try to restart Plume
 
     let rocket = rocket::custom(CONFIG.rocket.clone().unwrap())
         .mount(
+            "/custom_domains/",
+            routes![
+                routes::blogs::custom_details,
+                routes::blogs::custom_activity_details,
+            ],
+        )
+        .mount(
             "/",
             routes![
                 routes::blogs::details,

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,6 +207,10 @@ Then try to restart Plume
             ],
         )
         .mount(
+            "/domain_validation/",
+            routes![routes::blogs::domain_validation,],
+        )
+        .mount(
             "/",
             routes![
                 routes::blogs::details,

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,6 +201,7 @@ Then try to restart Plume
             "/custom_domains/",
             routes![
                 routes::blogs::custom_details,
+                routes::posts::custom_details,
                 routes::blogs::custom_activity_details,
                 routes::search::custom_search,
             ],

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,10 +200,10 @@ Then try to restart Plume
         .mount(
             "/custom_domains/",
             routes![
-                routes::blogs::custom_details,
-                routes::posts::custom_details,
-                routes::blogs::custom_activity_details,
-                routes::search::custom_search,
+                routes::blogs::custom::details,
+                routes::posts::custom::details,
+                routes::blogs::custom::activity_details,
+                routes::search::custom::search,
             ],
         )
         .mount(

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,9 @@ Then try to restart Plume
         println!("Please refer to the documentation to see how to configure it.");
     }
 
+    let custom_domains = plume_models::blogs::Blog::list_custom_domains(&dbpool.get().unwrap()).unwrap();
+    dbg!(custom_domains);
+
     let rocket = rocket::custom(CONFIG.rocket.clone().unwrap())
         .mount(
             "/",

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ use plume_models::{
     search::{Searcher as UnmanagedSearcher, SearcherError},
     Connection, Error, CONFIG,
 };
-use rocket::{fairing::AdHoc, http::uri::Origin};
+use rocket::{fairing::AdHoc, http::ext::IntoOwned, http::uri::Origin};
 use rocket_csrf::CsrfFairingBuilder;
 use scheduled_thread_pool::ScheduledThreadPool;
 use std::process::exit;
@@ -183,7 +183,9 @@ Then try to restart Plume
         let host = req.guard::<Host>();
         if host.is_success() {
             let rewrite_uri = format!("/custom_domains/{}/{}", host.unwrap(), req.uri());
-            req.set_uri(Origin::parse_owned(rewrite_uri).unwrap())
+            let uri = Origin::parse_owned(rewrite_uri).unwrap();
+            let uri = uri.to_normalized().into_owned();
+            req.set_uri(uri);
         }
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-#![feature(decl_macro, proc_macro_hygiene, checked_duration_since, try_trait)]
+#![feature(decl_macro, proc_macro_hygiene, try_trait)]
 
 extern crate activitypub;
 extern crate askama_escape;
@@ -197,7 +197,7 @@ Then try to restart Plume
         }
     });
 
-    let mut valid_domains: HashMap<&str, Instant> = HashMap::new();
+    let valid_domains: HashMap<String, Instant> = HashMap::new();
     let rocket = rocket::custom(CONFIG.rocket.clone().unwrap())
         .mount(
             "/custom_domains/",
@@ -324,7 +324,7 @@ Then try to restart Plume
         .manage(dbpool)
         .manage(Arc::new(workpool))
         .manage(searcher)
-        .manage(valid_domains)
+        .manage(Mutex::new(valid_domains))
         .manage(include_i18n!())
         .attach(
             CsrfFairingBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern crate num_cpus;
 extern crate plume_api;
 extern crate plume_common;
 extern crate plume_models;
+extern crate reqwest;
 #[macro_use]
 extern crate rocket;
 extern crate rocket_contrib;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-#![feature(decl_macro, proc_macro_hygiene, try_trait)]
+#![feature(decl_macro, proc_macro_hygiene, checked_duration_since, try_trait)]
 
 extern crate activitypub;
 extern crate askama_escape;
@@ -53,9 +53,10 @@ use plume_models::{
 use rocket::{fairing::AdHoc, http::ext::IntoOwned, http::uri::Origin};
 use rocket_csrf::CsrfFairingBuilder;
 use scheduled_thread_pool::ScheduledThreadPool;
+use std::collections::HashMap;
 use std::process::exit;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 init_i18n!(
     "plume", ar, bg, ca, cs, de, en, eo, es, fr, gl, hi, hr, it, ja, nb, pl, pt, ro, ru, sr, sk, sv
@@ -196,6 +197,7 @@ Then try to restart Plume
         }
     });
 
+    let mut valid_domains: HashMap<&str, Instant> = HashMap::new();
     let rocket = rocket::custom(CONFIG.rocket.clone().unwrap())
         .mount(
             "/custom_domains/",
@@ -322,6 +324,7 @@ Then try to restart Plume
         .manage(dbpool)
         .manage(Arc::new(workpool))
         .manage(searcher)
+        .manage(valid_domains)
         .manage(include_i18n!())
         .attach(
             CsrfFairingBuilder::new()

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -216,7 +216,7 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket) -> RespondOr
         )
         .into()
     } else {
-        Flash::warn(
+        Flash::warning(
             Redirect::to(uri!(details: name = slug.clone(), page = _)),
             &i18n!(intl, "Your blog was successfully created, but the custom domain seems invalid. Please check it is correct from your blog's settings."),
         )

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -99,7 +99,7 @@ pub fn new(rockets: PlumeRocket, _user: User) -> Ructe {
     ))
 }
 
-#[get("/validate/<validation_id>")]
+#[get("/domain_validation/<validation_id>")]
 pub fn domain_validation(
     validation_id: String,
     valid_domains: State<Mutex<HashMap<String, Instant>>>,

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -333,6 +333,7 @@ pub struct EditForm {
     pub summary: String,
     pub icon: Option<i32>,
     pub banner: Option<i32>,
+    pub custom_domain: Option<Host>,
 }
 
 #[get("/~/<name>/edit")]
@@ -359,6 +360,7 @@ pub fn edit(name: String, rockets: PlumeRocket) -> Result<Ructe, ErrorPage> {
                 summary: blog.summary.clone(),
                 icon: blog.icon_id,
                 banner: blog.banner_id,
+                custom_domain: blog.custom_domain.clone(),
             },
             ValidationErrors::default()
         )))

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -136,6 +136,7 @@ pub fn new_auth(i18n: I18n) -> Flash<Redirect> {
 pub struct NewBlogForm {
     #[validate(custom(function = "valid_slug", message = "Invalid name"))]
     pub title: String,
+    pub custom_domain: String,
 }
 
 fn valid_slug(title: &str) -> Result<(), ValidationError> {
@@ -153,6 +154,12 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket) -> RespondOr
     let conn = &*rockets.conn;
     let intl = &rockets.intl.catalog;
     let user = rockets.user.clone().unwrap();
+
+    let custom_domain = if *(&form.custom_domain.is_empty()) {
+        None
+    } else {
+        Some(Host::new(*(&form.custom_domain)))
+    };
 
     let mut errors = match form.validate() {
         Ok(_) => ValidationErrors::new(),
@@ -185,6 +192,7 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket) -> RespondOr
             Instance::get_local()
                 .expect("blog::create: instance error")
                 .id,
+            custom_domain,
         )
         .expect("blog::create: new local error"),
     )

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -99,7 +99,8 @@ pub fn new(rockets: PlumeRocket, _user: User) -> Ructe {
     ))
 }
 
-#[get("/domain_validation/<validation_id>")]
+// mounted as /domain_validation/
+#[get("/<validation_id>")]
 pub fn domain_validation(
     validation_id: String,
     valid_domains: State<Mutex<HashMap<String, Instant>>>,
@@ -132,7 +133,11 @@ pub fn domain_validation(
 pub mod custom {
     use plume_common::activity_pub::{ActivityStream, ApRequest};
     use plume_models::{blogs::Blog, blogs::CustomGroup, blogs::Host, PlumeRocket};
+    use rocket::{http::Status, State};
     use routes::{errors::ErrorPage, Page, RespondOrRedirect};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::Instant;
 
     #[get("/<custom_domain>?<page>", rank = 2)]
     pub fn details(
@@ -152,6 +157,15 @@ pub mod custom {
     ) -> Option<ActivityStream<CustomGroup>> {
         let blog = Blog::find_by_host(&rockets, Host::new(custom_domain)).ok()?;
         super::activity_detail_guts(blog, rockets, _ap)
+    }
+
+    // mounted as /custom_domains/domain_validation/
+    #[get("/<validation_id>")]
+    pub fn domain_validation(
+        validation_id: String,
+        valid_domains: State<Mutex<HashMap<String, Instant>>>,
+    ) -> Status {
+        super::domain_validation(validation_id, valid_domains)
     }
 }
 

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -158,7 +158,7 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket) -> RespondOr
     let custom_domain = if *(&form.custom_domain.is_empty()) {
         None
     } else {
-        Some(Host::new(*(&form.custom_domain)))
+        Some(Host::new(form.custom_domain.clone()))
     };
 
     let mut errors = match form.validate() {

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -68,7 +68,7 @@ pub fn details(
 
     match (blog.custom_domain, page) {
         (Some(ref custom_domain), Some(ref page)) => {
-            Ok(Redirect::to(format!("https://{}/?{}", custom_domain, page)).into())
+            Ok(Redirect::to(format!("https://{}/?page={}", custom_domain, page)).into())
         }
         (Some(ref custom_domain), _) => {
             Ok(Redirect::to(format!("https://{}/", custom_domain)).into())

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -19,6 +19,16 @@ use plume_models::{
 use routes::{errors::ErrorPage, Page, RespondOrRedirect};
 use template_utils::{IntoContext, Ructe};
 
+#[get("/<custom_domain>?<page>", rank = 2)]
+pub fn custom_details(
+    custom_domain: String,
+    page: Option<Page>,
+    rockets: PlumeRocket,
+) -> Result<Ructe, ErrorPage> {
+    let blog = Blog::find_by_host(&rockets, Host::new(custom_domain))?;
+    details(blog.fqn, page, rockets)
+}
+
 #[get("/~/<name>?<page>", rank = 2)]
 pub fn details(name: String, page: Option<Page>, rockets: PlumeRocket) -> Result<Ructe, ErrorPage> {
     let page = page.unwrap_or_default();
@@ -36,6 +46,16 @@ pub fn details(name: String, page: Option<Page>, rockets: PlumeRocket) -> Result
         Page::total(articles_count as i32),
         posts
     )))
+}
+
+#[get("/<custom_domain>", rank = 1)]
+pub fn custom_activity_details(
+    custom_domain: String,
+    rockets: PlumeRocket,
+    _ap: ApRequest,
+) -> Option<ActivityStream<CustomGroup>> {
+    let blog = Blog::find_by_host(&rockets, Host::new(custom_domain)).ok()?;
+    activity_details(blog.fqn, rockets, _ap)
 }
 
 #[get("/~/<name>", rank = 1)]

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -123,7 +123,7 @@ pub fn domain_validation(
     if now.duration_since(*valid_until).as_secs() > 0 {
         validation_map.remove(&validation_id);
         // don't know how to cast Status::Gone to u16
-        return Status::new(410, "validation expired");
+        return Custom(Status::Gone, "validation expired");
     }
 
     validation_map.remove(&validation_id);

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -111,8 +111,8 @@ pub fn domain_validation(
 
     let value = validation_getter.get(&validation_id);
     if value.is_none() {
-        // don't know how to cast Status::NotFound to u16
-        return Status::new(404, "validation id not found");
+        // validation id not found
+        return Status::NotFound;
     }
 
     // we have valid id, now check the time
@@ -122,8 +122,8 @@ pub fn domain_validation(
     // nope, expired (410: gone)
     if now.duration_since(*valid_until).as_secs() > 0 {
         validation_map.remove(&validation_id);
-        // don't know how to cast Status::Gone to u16
-        return Custom(Status::Gone, "validation expired");
+        // validation expired
+        return Status::Gone;
     }
 
     validation_map.remove(&validation_id);

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -95,6 +95,11 @@ pub fn new(rockets: PlumeRocket, _user: User) -> Ructe {
     ))
 }
 
+#[get("/validate/<validation_id>")]
+pub fn validate(validation_id: String, rockets: PlumeRocket) -> Result {
+    unimplemented!("No idea what to do here yet")
+}
+
 pub mod custom {
     use plume_common::activity_pub::{ActivityStream, ApRequest};
     use plume_models::{blogs::Blog, blogs::CustomGroup, blogs::Host, PlumeRocket};

--- a/src/routes/blogs.rs
+++ b/src/routes/blogs.rs
@@ -155,7 +155,7 @@ pub fn create(form: LenientForm<NewBlogForm>, rockets: PlumeRocket) -> RespondOr
     let intl = &rockets.intl.catalog;
     let user = rockets.user.clone().unwrap();
 
-    let custom_domain = if *(&form.custom_domain.is_empty()) {
+    let custom_domain = if form.custom_domain.is_empty() {
         None
     } else {
         Some(Host::new(form.custom_domain.clone()))

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -14,12 +14,6 @@ impl From<Error> for ErrorPage {
     }
 }
 
-impl From<diesel::result::Error> for ErrorPage {
-    fn from(err: diesel::result::Error) -> ErrorPage {
-        ErrorPage(plume_models::Error::Db(err))
-    }
-}
-
 impl<'r> Responder<'r> for ErrorPage {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
         let rockets = req.guard::<PlumeRocket>().unwrap();

--- a/src/routes/errors.rs
+++ b/src/routes/errors.rs
@@ -14,6 +14,12 @@ impl From<Error> for ErrorPage {
     }
 }
 
+impl From<diesel::result::Error> for ErrorPage {
+    fn from(err: diesel::result::Error) -> ErrorPage {
+        ErrorPage(plume_models::Error::Db(err))
+    }
+}
+
 impl<'r> Responder<'r> for ErrorPage {
     fn respond_to(self, req: &Request) -> response::Result<'r> {
         let rockets = req.guard::<PlumeRocket>().unwrap();

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,6 +10,7 @@ use rocket::{
     response::{Flash, NamedFile, Redirect},
     Outcome,
 };
+use std::fmt;
 use std::path::{Path, PathBuf};
 use template_utils::Ructe;
 
@@ -52,8 +53,14 @@ impl From<Flash<Redirect>> for RespondOrRedirect {
     }
 }
 
-#[derive(Shrinkwrap, Copy, Clone, UriDisplayQuery)]
+#[derive(Debug, Shrinkwrap, Copy, Clone, UriDisplayQuery)]
 pub struct Page(i32);
+
+impl fmt::Display for Page {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl<'v> FromFormValue<'v> for Page {
     type Error = &'v RawStr;

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -144,14 +144,14 @@ pub fn details(
 
     match (blog.custom_domain, responding_to) {
         (Some(ref custom_domain), Some(ref responding_to)) => Ok(Redirect::to(format!(
-            "https://{}/?responding_to={}",
-            custom_domain, responding_to
+            "https://{}/{}?responding_to={}",
+            custom_domain, slug, responding_to
         ))
         .into()),
         (Some(ref custom_domain), _) => {
-            Ok(Redirect::to(format!("https://{}/", custom_domain)).into())
+            Ok(Redirect::to(format!("https://{}/{}", custom_domain, slug)).into())
         }
-        (None, _) => panic!("This code path should have already been handled!"),
+        (None, _) => unreachable!("This code path should have already been handled!"),
     }
 }
 

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -133,7 +133,7 @@ pub mod custom {
     use routes::{errors::ErrorPage, RespondOrRedirect};
     use template_utils::{IntoContext, Ructe};
 
-    #[get("/custom_domains/<custom_domain>/<slug>?<responding_to>", rank = 4)]
+    #[get("/<custom_domain>/<slug>?<responding_to>", rank = 4)]
     pub fn details(
         custom_domain: String,
         slug: String,

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -31,28 +31,14 @@ use routes::{
 };
 use template_utils::{IntoContext, Ructe};
 
-#[get("/~/<blog>/<slug>?<responding_to>", rank = 4)]
-pub fn details(
-    blog: String,
-    slug: String,
+fn detail_guts(
+    blog: &Blog,
+    post: &Post,
     responding_to: Option<i32>,
-    rockets: PlumeRocket,
-) -> Result<Ructe, ErrorPage> {
+    rockets: &PlumeRocket,
+) -> Result<RespondOrRedirect, ErrorPage> {
     let conn = &*rockets.conn;
     let user = rockets.user.clone();
-    let blog = Blog::find_by_fqn(&rockets, &blog)?;
-    let post = Post::find_by_slug(&*conn, &slug, blog.id)?;
-    if !(post.published
-        || post
-            .get_authors(&*conn)?
-            .into_iter()
-            .any(|a| a.id == user.clone().map(|u| u.id).unwrap_or(0)))
-    {
-        return Ok(render!(errors::not_authorized(
-            &rockets.to_context(),
-            i18n!(rockets.intl.catalog, "This post isn't published yet.")
-        )));
-    }
 
     let comments = CommentTree::from_post(&*conn, &post, user.as_ref())?;
 
@@ -61,7 +47,7 @@ pub fn details(
     Ok(render!(posts::details(
             &rockets.to_context(),
             post.clone(),
-            blog,
+            blog.clone(),
             &NewCommentForm {
                 warning: previous.clone().map(|p| p.spoiler_text).unwrap_or_default(),
                 content: previous.clone().and_then(|p| Some(format!(
@@ -94,7 +80,79 @@ pub fn details(
             user.clone().and_then(|u| u.has_reshared(&*conn, &post).ok()).unwrap_or(false),
             user.and_then(|u| u.is_following(&*conn, post.get_authors(&*conn).ok()?[0].id).ok()).unwrap_or(false),
             post.get_authors(&*conn)?[0].clone()
-        )))
+        )).into())
+}
+
+#[get("/custom_domains/<custom_domain>/<slug>?<responding_to>", rank = 4)]
+pub fn custom_details(
+    custom_domain: String,
+    slug: String,
+    responding_to: Option<i32>,
+    rockets: PlumeRocket,
+) -> Result<RespondOrRedirect, ErrorPage> {
+    let conn = &*rockets.conn;
+    let user = rockets.user.clone();
+    let blog = Blog::find_by_host(&rockets, Host::new(custom_domain))?;
+    let post = Post::find_by_slug(&*conn, &slug, blog.id)?;
+    if !(post.published
+        || post
+            .get_authors(&*conn)?
+            .into_iter()
+            .any(|a| a.id == user.clone().map(|u| u.id).unwrap_or(0)))
+    {
+        return Ok(render!(errors::not_authorized(
+            &rockets.to_context(),
+            i18n!(rockets.intl.catalog, "This post isn't published yet.")
+        ))
+        .into());
+    }
+
+    detail_guts(&blog, &post, responding_to, &rockets)
+}
+
+#[get("/~/<blog>/<slug>?<responding_to>", rank = 4)]
+pub fn details(
+    blog: String,
+    slug: String,
+    responding_to: Option<i32>,
+    rockets: PlumeRocket,
+) -> Result<RespondOrRedirect, ErrorPage> {
+    let conn = &*rockets.conn;
+    let user = rockets.user.clone();
+    let blog = Blog::find_by_fqn(&rockets, &blog)?;
+    let post = Post::find_by_slug(&*conn, &slug, blog.id)?;
+
+    if !(post.published
+        || post
+            .get_authors(&*conn)?
+            .into_iter()
+            .any(|a| a.id == user.clone().map(|u| u.id).unwrap_or(0)))
+    {
+        return Ok(render!(errors::not_authorized(
+            &rockets.to_context(),
+            i18n!(rockets.intl.catalog, "This post isn't published yet.")
+        ))
+        .into());
+    }
+
+    // check this first, and return early
+    // doing this prevents partially moving `blog` into the `match (tuple)`,
+    // which makes it impossible to reuse then.
+    if blog.custom_domain == None {
+        return detail_guts(&blog, &post, responding_to, &rockets);
+    }
+
+    match (blog.custom_domain, responding_to) {
+        (Some(ref custom_domain), Some(ref responding_to)) => Ok(Redirect::to(format!(
+            "https://{}/?responding_to={}",
+            custom_domain, responding_to
+        ))
+        .into()),
+        (Some(ref custom_domain), _) => {
+            Ok(Redirect::to(format!("https://{}/", custom_domain)).into())
+        }
+        (None, _) => panic!("This code path should have already been handled!"),
+    }
 }
 
 #[get("/~/<blog>/<slug>", rank = 3)]

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -49,8 +49,7 @@ macro_rules! param_to_query {
     }
 }
 
-#[get("/search?<query..>")]
-pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
+fn search_guts(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
     let conn = &*rockets.conn;
     let query = query.map(Form::into_inner).unwrap_or_default();
     let page = query.page.unwrap_or_default();
@@ -82,4 +81,18 @@ pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
             next_page
         ))
     }
+}
+
+#[get("/search?<query..>")]
+pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
+    search_guts(query, rockets)
+}
+
+#[get("/<_custom_domain>/search?<query..>")]
+pub fn custom_search(
+    _custom_domain: String,
+    query: Option<Form<SearchQuery>>,
+    rockets: PlumeRocket,
+) -> Ructe {
+    search_guts(query, rockets)
 }

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -88,11 +88,17 @@ pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
     search_guts(query, rockets)
 }
 
-#[get("/<_custom_domain>/search?<query..>")]
-pub fn custom_search(
-    _custom_domain: String,
-    query: Option<Form<SearchQuery>>,
-    rockets: PlumeRocket,
-) -> Ructe {
-    search_guts(query, rockets)
+pub mod custom {
+    use plume_models::PlumeRocket;
+    use rocket::request::Form;
+    use template_utils::Ructe;
+
+    #[get("/<_custom_domain>/search?<query..>")]
+    pub fn search(
+        _custom_domain: String,
+        query: Option<Form<super::SearchQuery>>,
+        rockets: PlumeRocket,
+    ) -> Ructe {
+        super::search_guts(query, rockets)
+    }
 }

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -390,10 +390,13 @@ macro_rules! url {
                               $($custom_args = $custom_args,)*
                               );
             let path = origin
-                .segments() // first segment is /custom_domain,
-                .skip(2)// second is <domain>, drop both
+                .segments()
+                .skip(1)// skip is <custom_domain> part
                 .map(|seg| format!("/{}", seg)).collect::<String>();
-            let query = origin.query().map(|q| format!("?{}", q)).unwrap_or_default();
+            let query = origin.query()
+                .filter(|q| !q.is_empty())
+                .map(|q| format!("?{}", q))
+                .unwrap_or_default();
             format!("https://{}{}{}", &domain, path, query)
         } else {
             $(

--- a/src/template_utils.rs
+++ b/src/template_utils.rs
@@ -389,7 +389,10 @@ macro_rules! url {
                               $($common_args = $common_args,)*
                               $($custom_args = $custom_args,)*
                               );
-            let path = origin.segments().skip(1).map(|seg| format!("/{}", seg)).collect::<String>(); //first segment is domain, drop it
+            let path = origin
+                .segments() // first segment is /custom_domain,
+                .skip(2)// second is <domain>, drop both
+                .map(|seg| format!("/{}", seg)).collect::<String>();
             let query = origin.query().map(|q| format!("?{}", q)).unwrap_or_default();
             format!("https://{}{}{}", &domain, path, query)
         } else {

--- a/templates/blogs/details.rs.html
+++ b/templates/blogs/details.rs.html
@@ -13,8 +13,8 @@
 	<meta content="120" property="og:image:width" />
 	<meta content="120" property="og:image:height" />
 	<meta content="summary" property="twitter:card" />
-	<meta content="'@Instance::get_local().unwrap().name" property="og:site_name" />
-	<meta content="@blog.ap_url" property="og:url" />
+	<meta content="@Instance::get_local().unwrap().name" property="og:site_name" />
+	<meta content="@blog.url()" property="og:url" />
 	<meta content="@blog.fqn" property="profile:username" />
 	<meta content="@blog.title" property="og:title" />
 	<meta content="@blog.summary_html" name="description">

--- a/templates/blogs/details.rs.html
+++ b/templates/blogs/details.rs.html
@@ -24,7 +24,7 @@
 	<link href='@Instance::get_local().unwrap().compute_box("~", &blog.fqn, "atom.xml")' rel='alternate' type='application/atom+xml'>
 	<link href='@blog.ap_url' rel='alternate' type='application/activity+json'>
 }, {
-    <a href="@url!(custom_domain = *&blog.custom_domain, blogs::details: common=[page = None], normal=[name = &blog.fqn])" dir="auto">@blog.title</a>
+    <a href="@url!(custom_domain = blog.custom_domain, blogs::details: common=[page = None], normal=[name = &blog.fqn])" dir="auto">@blog.title</a>
 }, {
 <div class="hidden">
     @for author in authors {

--- a/templates/blogs/details.rs.html
+++ b/templates/blogs/details.rs.html
@@ -24,7 +24,7 @@
 	<link href='@Instance::get_local().unwrap().compute_box("~", &blog.fqn, "atom.xml")' rel='alternate' type='application/atom+xml'>
 	<link href='@blog.ap_url' rel='alternate' type='application/activity+json'>
 }, {
-    <a href="@uri!(blogs::details: name = &blog.fqn, page = _)" dir="auto">@blog.title</a>
+    <a href="@url!(custom_domain = *&blog.custom_domain, blogs::details: common=[page = None], normal=[name = &blog.fqn])" dir="auto">@blog.title</a>
 }, {
 <div class="hidden">
     @for author in authors {
@@ -55,7 +55,7 @@
                     <a href="@uri!(blogs::edit: name = &blog.fqn)" class="button" dir="auto">@i18n!(ctx.1, "Edit")</a>
                 }
             </div>
-            
+
             <main class="user-summary" dir="auto">
                 <p>
                     @i18n!(ctx.1, "There's one author on this blog: ", "There are {0} authors on this blog: "; authors.len())

--- a/templates/blogs/edit.rs.html
+++ b/templates/blogs/edit.rs.html
@@ -23,6 +23,8 @@
         <label for="summary">@i18n!(ctx.1, "Description")<small>@i18n!(ctx.1, "Markdown syntax is supported")</small></label>
         <textarea id="summary" name="summary" rows="20">@form.summary</textarea>
 
+        @input!(ctx.1, custom_domain (optional text), "Custom Domain", form, errors, "")
+
         <p>
             @i18n!(ctx.1, "You can upload images to your gallery, to use them as blog icons, or banners.")
             <a href="@uri!(medias::new)">@i18n!(ctx.1, "Upload images")</a>

--- a/templates/blogs/new.rs.html
+++ b/templates/blogs/new.rs.html
@@ -9,10 +9,10 @@
 @:base(ctx, i18n!(ctx.1, "New Blog"), {}, {}, {
   <h1 dir="auto">@i18n!(ctx.1, "Create a blog")</h1>
   <form method="post" action="@uri!(blogs::create)">
-      @input!(ctx.1, title (text), "Title", form, errors, "required minlength=\"1\"")
+      @input!(ctx.1, title (text), "Title", form, errors.clone(), "required minlength=\"1\"")
       <input type="submit" value="@i18n!(ctx.1, "Create blog")" dir="auto"/>
 
-      @input!(ctx.1, custom_domain (optional text), "Custom Domain", form, errors.clone(), "")
+      @input!(ctx.1, custom_domain (optional text), "Custom Domain", form, errors, "")
       <input type="submit" value="@i18n!(ctx.1, "Make your blog available under a custom domain")" dir="auto"/>
   </form>
 })

--- a/templates/blogs/new.rs.html
+++ b/templates/blogs/new.rs.html
@@ -11,5 +11,8 @@
   <form method="post" action="@uri!(blogs::create)">
       @input!(ctx.1, title (text), "Title", form, errors, "required minlength=\"1\"")
       <input type="submit" value="@i18n!(ctx.1, "Create blog")" dir="auto"/>
+
+      @input!(ctx.1, custom_domain (optional text), "Custom Domain", form, errors.clone(), "")
+      <input type="submit" value="@i18n!(ctx.1, "Make your blog available under a custom domain")" dir="auto"/>
   </form>
 })

--- a/templates/partials/post_card.rs.html
+++ b/templates/partials/post_card.rs.html
@@ -9,7 +9,7 @@
         <div class="cover" style="background-image: url('@Html(article.cover_url(ctx.0).unwrap_or_default())')"></div>
     }
     <h3 class="p-name" dir="auto">
-        <a class="u-url" href="@uri!(posts::details: blog = article.get_blog(ctx.0).unwrap().fqn, slug = &article.slug, responding_to = _)">
+        <a class="u-url" href="@url!(custom_domain = article.get_blog(ctx.0).unwrap().custom_domain, posts::details: common=[ slug = &article.slug, responding_to = None], normal=[blog = article.get_blog(ctx.0).unwrap().fqn])">
             @article.title
         </a>
     </h3>
@@ -25,10 +25,9 @@
         @if article.published {
 	       ⋅ <span class="dt-published" datetime="@article.creation_date.format("%F %T")">@article.creation_date.format("%B %e, %Y")</span>
         }
-        ⋅ <a href="@uri!(blogs::details: name = &article.get_blog(ctx.0).unwrap().fqn, page = _)">@article.get_blog(ctx.0).unwrap().title</a>
+        ⋅ <a href="@url!(custom_domain = article.get_blog(ctx.0).unwrap().custom_domain, blogs::details: common=[page = None], normal=[name = &article.get_blog(ctx.0).unwrap().fqn])">@article.get_blog(ctx.0).unwrap().title</a>
         @if !article.published {
             ⋅ @i18n!(ctx.1, "Draft")
         }
     </footer>
 </div>
-

--- a/templates/partials/post_card.rs.html
+++ b/templates/partials/post_card.rs.html
@@ -9,7 +9,7 @@
         <div class="cover" style="background-image: url('@Html(article.cover_url(ctx.0).unwrap_or_default())')"></div>
     }
     <h3 class="p-name" dir="auto">
-        <a class="u-url" href="@url!(custom_domain = article.get_blog(ctx.0).unwrap().custom_domain, posts::details: common=[ slug = &article.slug, responding_to = None], normal=[blog = article.get_blog(ctx.0).unwrap().fqn])">
+        <a class="u-url" href="@url!(custom_domain = article.get_blog(ctx.0).unwrap().custom_domain, posts::details: common=[ slug = &article.slug, responding_to = NoValue], normal=[blog = article.get_blog(ctx.0).unwrap().fqn])">
             @article.title
         </a>
     </h3>

--- a/templates/posts/details.rs.html
+++ b/templates/posts/details.rs.html
@@ -17,10 +17,10 @@
     @if article.cover_id.is_some() {
         <meta property="og:image" content="@Html(article.cover_url(ctx.0).unwrap_or_default())"/>
     }
-    <meta property="og:url" content="@uri!(posts::details: blog = &blog.fqn, slug = &article.slug, responding_to = _)"/>
+        <meta property="og:url" content="@url!(custom_domain = *&blog.custom_domain, posts::details: common=[slug = &article.slug, responding_to = None], normal=[blog = &blog.fqn])"/>
     <meta property="og:description" content="@article.subtitle"/>
 }, {
-    <a href="@uri!(blogs::details: name = &blog.fqn, page = _)">@blog.title</a>
+    <a href="@url!(custom_domain = &blog.custom_domain, blogs::details: common=[page = None], normal=[name = &blog.fqn])">@blog.title</a>
 }, {
 <div class="h-entry">
     <header
@@ -54,7 +54,7 @@
             <ul class="tags" dir="auto">
                 @for tag in tags {
                     @if !tag.is_hashtag {
-                        <li><a class="p-category" href="@uri!(tags::tag: name = &tag.tag, page = _)">@tag.tag</a></li>
+                        <li><a class="p-category" href="@uri!(tags::tag: name = &tag.tag, page = None)">@tag.tag</a></li>
                     } else {
                         <span class="hidden p-category">@tag.tag</span>
                     }

--- a/templates/posts/details.rs.html
+++ b/templates/posts/details.rs.html
@@ -17,7 +17,7 @@
     @if article.cover_id.is_some() {
         <meta property="og:image" content="@Html(article.cover_url(ctx.0).unwrap_or_default())"/>
     }
-        <meta property="og:url" content="@url!(custom_domain = *&blog.custom_domain, posts::details: common=[slug = &article.slug, responding_to = None], normal=[blog = &blog.fqn])"/>
+        <meta property="og:url" content="@url!(custom_domain = blog.custom_domain, posts::details: common=[slug = &article.slug, responding_to = NoValue], normal=[blog = &blog.fqn])"/>
     <meta property="og:description" content="@article.subtitle"/>
 }, {
     <a href="@url!(custom_domain = &blog.custom_domain, blogs::details: common=[page = None], normal=[name = &blog.fqn])">@blog.title</a>


### PR DESCRIPTION
This Pull Request addresses #94; replaces #447;
We start by adding `custom_domain` to the `blogs` table; and a custom type Host(String)

A blog with `custom_domain` has special routes with higher priority, but administrative routes will remain on the instance host.

We'll use `Fairings` to extract the `Host` header, to then specially route them.

Domain administration is left to the user (and/or admin)
(but we might be able to provide a check on whether it's already correctly configured)

-------

## TODO

- [x] PostgreSQL Migrations
- [x] SQLite Migrations
- [x] Custom time to represent domain (`Host`)
- [x] Expand `Blog` (and `NewBlog`)
- [x] Update `/blog/new` and `/blog/edit` to add custom domain field
- [x] Cache custom domains on startup and on insert/update.
- [x] `/custom_domains/` mount-point which handles these domains
- [ ] implement routes for
    - [x] blog details
    - [x] post details 
    - [x] blog activity_details
    - [ ] search
    - [ ] routes necessary for federation??
- [ ] implement redirect for the "legacy" routes for the above
    - [x] blog details
    - [x] post details
    - [ ] blog activity_details ??
    - [ ] search
- [x] Update URLs in templates
- [ ] Update URLs in base template for search
- [ ] Check correct domain setup
- [ ] Test: Federation
- [ ] Some explanations (in the UI, next to the setting and in the docs)