### PR TITLE
Add clap to plume in order to print help and version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "askama_escape 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atom_syndication 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Plume-org/Plume"
 activitypub = "0.1.3"
 askama_escape = "0.1"
 atom_syndication = "0.6"
+clap = "2.33"
 colored = "1.8"
 dotenv = "0.14"
 gettext = { git = "https://github.com/Plume-org/gettext/", rev = "294c54d74c699fbc66502b480a37cc66c1daa7f3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ extern crate activitypub;
 extern crate askama_escape;
 extern crate atom_syndication;
 extern crate chrono;
+extern crate clap;
 extern crate colored;
 extern crate ctrlc;
 extern crate diesel;
@@ -38,6 +39,7 @@ extern crate validator;
 extern crate validator_derive;
 extern crate webfinger;
 
+use clap::App;
 use diesel::r2d2::ConnectionManager;
 use plume_models::{
     db_conn::{DbPool, PragmaForeignKey},
@@ -85,6 +87,17 @@ fn init_pool() -> Option<DbPool> {
 }
 
 fn main() {
+    App::new("Plume")
+        .bin_name("plume")
+        .version(env!("CARGO_PKG_VERSION"))
+        .about("Plume backend server")
+        .after_help(
+            r#"
+Be careful plume command should be run inside the directory
+containing .env file an static directory
+        "#,
+        )
+        .get_matches();
     let dbpool = init_pool().expect("main: database pool initialization error");
     if IMPORTED_MIGRATIONS
         .is_pending(&dbpool.get().unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,10 @@ fn main() {
         .about("Plume backend server")
         .after_help(
             r#"
-Be careful plume command should be run inside the directory
-containing .env file an static directory
+The plume command should be run inside the directory
+containing the `.env` configuration file and `static` directory.
+See https://docs.joinplu.me/installation/config
+and https://docs.joinplu.me/installation/init for more info.
         "#,
         )
         .get_matches();


### PR DESCRIPTION
Related to https://github.com/Plume-org/Plume/issues/594.

Output looks like :

```
Plume 0.3.0
Plume backend server

USAGE:
    plume

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information


Be careful plume command should be run inside the directory
containing .env file an static directory
```
         
