### PR TITLE
Fix issue #642, frontend not in english if the user language does not exist

### DIFF
--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -47,9 +47,11 @@ lazy_static! {
         let lang = js! { return navigator.language }.into_string().unwrap();
         let lang = lang.splitn(2, '-').next().unwrap_or("en");
 
-        let english_position = catalogs.iter()
-	    .position(|(language_code,_)| *language_code == "en").unwrap();
-	catalogs
+        let english_position = catalogs
+            .iter()
+            .position(|(language_code, _)| *language_code == "en")
+            .unwrap();
+        catalogs
             .iter()
             .find(|(l, _)| l == &lang)
             .unwrap_or(&catalogs[english_position])

--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -46,10 +46,13 @@ lazy_static! {
         let catalogs = include_i18n!();
         let lang = js! { return navigator.language }.into_string().unwrap();
         let lang = lang.splitn(2, '-').next().unwrap_or("en");
-        catalogs
+
+        let english_position = catalogs.iter()
+	    .position(|(language_code,_)| *language_code == "en").unwrap();
+	catalogs
             .iter()
             .find(|(l, _)| l == &lang)
-            .unwrap_or(&catalogs[0])
+            .unwrap_or(&catalogs[english_position])
             .clone()
             .1
     };


### PR DESCRIPTION
Fix [#642](https://github.com/Plume-org/Plume/issues/642)

Iterate over catalogs to find the english index and then use it instead of 0.
