### PR TITLE
snap: Ensure cargo-web doesn't erroneously adopt our workspace.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,3 +48,6 @@ parts:
     plugin: rust
     source: https://github.com/koute/cargo-web.git
     source-tag: 0.6.26
+    override-pull: |
+        printf "\n[Workspace]\n" >> ${SNAPCRAFT_PART_SRC}/Cargo.toml
+        snapcraftctl pull


### PR DESCRIPTION
Because snapcraft pulls the source into a subdirectory of Plume's source, and
Cargo will implicitly and recursively search parent directories for a [Workspace],
Cargo believes that cargo-web should be in Plume's workspace.

However, Cargo then errors out because Plume's [Workspace] stanza (entirely correctly)
doens't mention cargo-web.

Adding an empty [Workspace] stanza to cargo-web's Cargo.toml disables Cargo's implicit
search for a workspace to adopt, and avoids this problem.