### PR TITLE
Don't split sentences for translations

### DIFF
--- a/templates/session/password_reset_request_expired.rs.html
+++ b/templates/session/password_reset_request_expired.rs.html
@@ -5,5 +5,5 @@
 
 @:base(ctx, i18n!(ctx.1, "Password reset"), {}, {}, {
   <h1>@i18n!(ctx.1, "This token has expired")</h1>
-  <p>@i18n!(ctx.1, "Please start the process again by clicking") <a href="/password-reset">@i18n!(ctx.1, "here")</a>.</p>
+  <p>@i18n!(ctx.1, "Please start the process again by clicking <a href="/password-reset">here</a>.")</p>
 })


### PR DESCRIPTION
Fixes #675

Also I've included the trailing period to the translatable string.
