### PR TITLE
Escape href quotation marks

### DIFF
--- a/templates/session/password_reset_request_expired.rs.html
+++ b/templates/session/password_reset_request_expired.rs.html
@@ -5,5 +5,5 @@
 
 @:base(ctx, i18n!(ctx.1, "Password reset"), {}, {}, {
   <h1>@i18n!(ctx.1, "This token has expired")</h1>
-  <p>@i18n!(ctx.1, "Please start the process again by clicking <a href="/password-reset">here</a>.")</p>
+  <p>@i18n!(ctx.1, "Please start the process again by clicking <a href=\"/password-reset\">here</a>.")</p>
 })


### PR DESCRIPTION
![Screenshot from 2019-10-17 07-23-33](https://user-images.githubusercontent.com/26003928/66963614-0ed08380-f0af-11e9-8445-fd3656bead14.png)

A follow-up to #677
This should fix the strings after the href attribute are ignored.
