### PR TITLE
Fix the profile editing form being untranslated(to anything)

### DIFF
--- a/templates/users/edit.rs.html
+++ b/templates/users/edit.rs.html
@@ -18,11 +18,11 @@
             <!-- Rocket hack to use various HTTP methods -->
             <input type=hidden name="_method" value="put">
 
-            @(Input::new("display_name", i18n!(ctx.1, ""))
+            @(Input::new("display_name", i18n!(ctx.1, "Display name"))
                 .default(&form.display_name)
                 .error(&errors)
                 .html(ctx.1))
-            @(Input::new("email", i18n!(ctx.1, ""))
+            @(Input::new("email", i18n!(ctx.1, "Email"))
                 .default(&form.email)
                 .error(&errors)
                 .input_type("email")


### PR DESCRIPTION
Prior to this, the display name and email address fields in the profile editor were labelled 
```Project-Id-Version: plume Report-Msgid-Bugs-To: PO-Revision-Date: 2019-04-17 20:49 Last-Translator: Ana Gelez (AnaGelez) Language-Team: English Language: en_US MIME-Version: 1.0 Content-Type: text/plain; charset=UTF-8 Content-Transfer-Encoding: 8bit Plural-Forms: nplurals=2; plural=(n != 1); X-Generator: crowdin.com X-Crowdin-Project: plume X-Crowdin-Language: en X-Crowdin-File: /master/po/plume/plume.pot ```

This seems to fix them