### PR TITLE
Add environmental variable to control path of media

### DIFF
--- a/plume-models/src/config.rs
+++ b/plume-models/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub rocket: Result<RocketConfig, RocketError>,
     pub logo: LogoConfig,
     pub default_theme: String,
+    pub media_directory: String,
 }
 
 #[derive(Debug, Clone)]
@@ -201,5 +202,7 @@ lazy_static! {
         rocket: get_rocket_config(),
         logo: LogoConfig::default(),
         default_theme: var("DEFAULT_THEME").unwrap_or_else(|_| "default-light".to_owned()),
+        media_directory: var("MEDIA_UPLOAD_DIRECTORY")
+            .unwrap_or_else(|_| "static/media".to_owned()),
     };
 }

--- a/plume-models/src/medias.rs
+++ b/plume-models/src/medias.rs
@@ -148,10 +148,12 @@ impl Media {
         if self.is_remote {
             Ok(self.remote_url.clone().unwrap_or_default())
         } else {
+            let p = Path::new(&self.file_path);
+            let filename: String = p.file_name().unwrap().to_str().unwrap().to_owned();
             Ok(ap_url(&format!(
-                "{}/{}",
+                "{}/static/media/{}",
                 Instance::get_local()?.public_domain,
-                self.file_path
+                &filename
             )))
         }
     }
@@ -202,10 +204,11 @@ impl Media {
             .next()
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| String::from("png"));
-        let path =
-            Path::new("static")
-                .join("media")
-                .join(format!("{}.{}", GUID::rand().to_string(), ext));
+        let path = Path::new(&super::CONFIG.media_directory).join(format!(
+            "{}.{}",
+            GUID::rand().to_string(),
+            ext
+        ));
 
         let mut dest = fs::File::create(path.clone()).ok()?;
         reqwest::get(remote_url.as_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,7 @@ Then try to restart Plume
                 routes::theme_files,
                 routes::plume_static_files,
                 routes::static_files,
+                routes::plume_media_files,
                 routes::tags::tag,
                 routes::timelines::details,
                 routes::timelines::new,

--- a/src/routes/medias.rs
+++ b/src/routes/medias.rs
@@ -3,7 +3,7 @@ use multipart::server::{
     save::{SaveResult, SavedData},
     Multipart,
 };
-use plume_models::{db_conn::DbConn, medias::*, users::User, Error, PlumeRocket};
+use plume_models::{db_conn::DbConn, medias::*, users::User, Error, PlumeRocket, CONFIG};
 use rocket::{
     http::ContentType,
     response::{status, Flash, Redirect},
@@ -72,7 +72,12 @@ pub fn upload(
                     .map(|ext| format!(".{}", ext))
             })
             .unwrap_or_default();
-        let dest = format!("static/media/{}{}", GUID::rand().to_string(), ext);
+        let dest = format!(
+            "{}/{}{}",
+            CONFIG.media_directory,
+            GUID::rand().to_string(),
+            ext
+        );
 
         match fields["file"][0].data {
             SavedData::Bytes(ref bytes) => fs::write(&dest, bytes)

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -17,8 +17,7 @@ use std::{
 };
 use template_utils::Ructe;
 
-use plume_models::{posts::Post, Connection};
-
+use plume_models::{posts::Post, Connection, CONFIG};
 const ITEMS_PER_PAGE: i32 = 12;
 
 /// Special return type used for routes that "cannot fail", and instead
@@ -212,7 +211,15 @@ pub fn theme_files(file: PathBuf, _build_id: &RawStr) -> Option<ThemeFile> {
 pub fn plume_static_files(file: PathBuf, _build_id: &RawStr) -> Option<CachedFile> {
     static_files(file)
 }
-
+#[get("/static/media/<file..>")]
+pub fn plume_media_files(file: PathBuf) -> Option<CachedFile> {
+    NamedFile::open(Path::new(&CONFIG.media_directory).join(file))
+        .ok()
+        .map(|f| CachedFile {
+            inner: f,
+            cache_control: CacheControl(vec![CacheDirective::MaxAge(60 * 60 * 24 * 30)]),
+        })
+}
 #[get("/static/<file..>", rank = 3)]
 pub fn static_files(file: PathBuf) -> Option<CachedFile> {
     NamedFile::open(Path::new("static/").join(file))


### PR DESCRIPTION
This was a request made on the matrix chat that will make it possible to release a snap version, that environmental variable being `MEDIA_UPLOAD_DIRECTORY`