### PR TITLE
"Manually" (with SQL) fill the default timelines

### DIFF
--- a/migrations/postgres/2019-06-24-101212_use_timelines_for_feed/up.sql
+++ b/migrations/postgres/2019-06-24-101212_use_timelines_for_feed/up.sql
@@ -16,5 +16,10 @@
 --#!	Ok(())
 --#!}
 
+-- The code above creates the timelines, but does not fill them. We do it "manually" for the local and federated timeline here:
+
+-- Add all local articles to the local timeline
 INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'local' LIMIT 1) FROM blogs INNER JOIN posts ON posts.blog_id = blogs.id WHERE blogs.instance_id = 1;
+
+-- Add all articles to the the federated timeline
 INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'all' LIMIT 1) FROM posts;

--- a/migrations/postgres/2019-06-24-101212_use_timelines_for_feed/up.sql
+++ b/migrations/postgres/2019-06-24-101212_use_timelines_for_feed/up.sql
@@ -15,3 +15,6 @@
 --#!
 --#!	Ok(())
 --#!}
+
+INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'local' LIMIT 1) FROM blogs INNER JOIN posts ON posts.blog_id = blogs.id WHERE blogs.instance_id = 1;
+INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'all' LIMIT 1) FROM posts;

--- a/migrations/sqlite/2019-06-24-105533_use_timelines_for_feed/up.sql
+++ b/migrations/sqlite/2019-06-24-105533_use_timelines_for_feed/up.sql
@@ -16,5 +16,11 @@
 --#!	Ok(())
 --#!}
 
+-- The code above creates the timelines, but does not fill them. We do it "manually" for the local and federated timeline here:
+
+-- Add all local articles to the local timeline
 INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'local' LIMIT 1) FROM blogs INNER JOIN posts ON posts.blog_id = blogs.id WHERE blogs.instance_id = 1;
+
+-- Add all articles to the the federated timeline
 INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'all' LIMIT 1) FROM posts;
+

--- a/migrations/sqlite/2019-06-24-105533_use_timelines_for_feed/up.sql
+++ b/migrations/sqlite/2019-06-24-105533_use_timelines_for_feed/up.sql
@@ -15,3 +15,6 @@
 --#!
 --#!	Ok(())
 --#!}
+
+INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'local' LIMIT 1) FROM blogs INNER JOIN posts ON posts.blog_id = blogs.id WHERE blogs.instance_id = 1;
+INSERT INTO timeline (post_id, timeline_id) SELECT posts.id, (SELECT id FROM timeline_definition WHERE query = 'all' LIMIT 1) FROM posts;


### PR DESCRIPTION
Fixes #692

Adding a plm command was too much refactoring (because the timelines need a `PlumeRocket` while `plm` only has a `Connection`), so I didn't do it.