### PR TITLE
Various snap fixes

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -38,6 +38,11 @@ then
 with 'snap restart plume'"
 fi
 
+if [ ! -d ${SNAP_DATA}/media ]
+then
+    mkdir ${SNAP_DATA}/media
+fi
+
 if [ "${enabled}" = "true" -a ! -e ${SNAP_COMMON}/initial-migrations-run ]
 then
     cd ${SNAP}

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,11 +1,4 @@
 #!/bin/sh
 
-db_type=$(snapctl get db.type)
-
-if [ -z "${db_type}" ]
-then
-    exit 0
-fi
-
 cd ${SNAP}
 exec ./set-environment bin/plm migration run --path ${SNAP_DATA}

--- a/snap/local/set-environment
+++ b/snap/local/set-environment
@@ -4,7 +4,7 @@ enabled="$(snapctl get enabled)"
 if [ -z "${enabled}" -o "${enabled}" != "true" ]
 then
     echo "Plume not yet enabled"
-    exit 1
+    exit 0
 fi
 
 export BASE_URL="$(snapctl get base-url)"

--- a/snap/local/set-environment
+++ b/snap/local/set-environment
@@ -24,6 +24,7 @@ ROCKET_ADDRESS="$(snapctl get listen.address)"
 ROCKET_PORT="$(snapctl get listen.port)"
 export ROCKET_SECRET_KEY="$(cat ${SNAP_COMMON}/rocket-secret-key)"
 export SEARCH_INDEX="${SNAP_DATA}/search_index"
+export MEDIA_UPLOAD_DIRECTORY="${SNAP_DATA}/media"
 
 cd ${SNAP}
 exec $@

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
       snapcraftctl set-version $(git describe --tags)
       export PATH=$PATH:$HOME/.cargo/bin
       rustup install stable
-      cargo +stable install cargo-web
+      cargo +stable install --force cargo-web
 
       # Only Tier 1 Rust platforms get rust-lld
       # On the others (arm64, armhf, powerpc64, s390x) fall back to using

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: plume
 base: core18
-version: '0.3.0' # just for humans, typically '1.2+git' or '1.3.2'
+adopt-info: plume
 summary: Multi-user blogging platform, federated over ActivityPub
 description: |
   Plume is a federated blogging platform, featuring:
@@ -34,6 +34,7 @@ parts:
       - on arm64,armhf,ppc64el,s390x:
         - lld-8
     override-build: |
+      snapcraftctl set-version $(git describe --tags)
       export PATH=$PATH:$HOME/.cargo/bin
       rustup install stable
       cargo +stable install cargo-web


### PR DESCRIPTION
This uses the new `MEDIA_UPLOAD_DIRECTORY` support to make media uploads work, cleans up some of the scripts, and sets the version based on git tags.