### PR TITLE
Fix #637 : Markdown footnotes

### DIFF
--- a/assets/themes/default/_article.scss
+++ b/assets/themes/default/_article.scss
@@ -481,3 +481,12 @@ input:checked ~ .cw-container > .cw-text {
     margin: auto $horizontal-margin;
   }
 }
+
+// Footnote related styles
+.footnote-definition {
+  p {
+    font-size: smaller;
+    // Make sur the definition is inline with the label-definition
+    display: inline;
+  }
+}

--- a/plume-models/src/safe_string.rs
+++ b/plume-models/src/safe_string.rs
@@ -31,6 +31,9 @@ lazy_static! {
             .add_tag_attributes("label", ["for"].iter())
             .add_tag_attributes("input", ["type", "checked"].iter())
             .add_allowed_classes("input", ["cw-checkbox"].iter())
+            // Related to https://github.com/Plume-org/Plume/issues/637
+            .add_allowed_classes("sup", ["footnote-reference", "footnote-definition-label"].iter())
+            .add_allowed_classes("div", ["footnote-definition"].iter())
             .add_allowed_classes("span", ["cw-container", "cw-text"].iter())
             .attribute_filter(|elem, att, val| match (elem, att) {
                 ("input", "type") => Some("checkbox".into()),


### PR DESCRIPTION
Here is fix for issue #637 that : 

- Ensure footnotes classes are not filtered by html sanitizer
- Add some footnote style rules

An example of footnotes using this fix :

**Markdown :** 

```md
Here is something[^a]


Here is another thing[^b]

[^a]: something

[^b]: another thing
```

![Footnotes rendeering](https://user-images.githubusercontent.com/17273325/69247036-0d144700-0baa-11ea-83bd-bbd9fa6564c4.png)

Note that there is some cpull-markdown related syntax : **a carriage return is needed between each note definition**