### PR TITLE
WIP: Fix RSS issues

### DIFF
--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -139,6 +139,7 @@ pub fn post_to_atom(post: Post, conn: &Connection) -> Entry {
                 })
                 .collect::<Vec<Person>>(),
         )
+        .id(post.id.to_string())
         .links(vec![LinkBuilder::default()
             .href(post.ap_url)
             .build()

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -139,6 +139,9 @@ pub fn post_to_atom(post: Post, conn: &Connection) -> Entry {
                 })
                 .collect::<Vec<Person>>(),
         )
+        // Using RFC 4287 format, see https://tools.ietf.org/html/rfc4287#section-3.3 for dates
+        // eg: 2003-12-13T18:30:02Z (Z is here because there is no timezone support with the NaiveDateTime crate)
+        .published(post.creation_date.format("%Y-%m-%dT%H:%M:%SZ").to_string())
         .id(post.id.to_string())
         .links(vec![LinkBuilder::default()
             .href(post.ap_url)


### PR DESCRIPTION
Here is a PR relative to issue #673.

At this state, the PR adds `id` and `published` field for each blog entry inside the RSS feed.

I'm not sure but it's look like there is no method or field attached to `post` struct to get information about update metadata.

I can add this but I want to be sure that it's in the scope of this PR.

Thanks for you're reply.