### PR TITLE
[wip] use Authorized fetch

### DIFF
--- a/plume-models/src/instance.rs
+++ b/plume-models/src/instance.rs
@@ -42,7 +42,6 @@ pub struct NewInstance {
 
 lazy_static! {
     static ref LOCAL_INSTANCE: RwLock<Option<Instance>> = RwLock::new(None);
-    static ref INSTANCE_USER: RwLock<Option<User>> = RwLock::new(None);
 }
 
 impl Instance {
@@ -57,15 +56,6 @@ impl Instance {
             .clone()
             .ok_or(Error::NotFound)
     }
-
-    pub fn set_local_user(u: User) {
-        INSTANCE_USER.write().unwrap().replace(u);
-    }
-
-    pub fn get_local_user() -> Result<User> {
-        INSTANCE_USER.read().unwrap().clone().ok_or(Error::NotFound)
-    }
-
     pub fn get_local_uncached(conn: &Connection) -> Result<Instance> {
         instances::table
             .filter(instances::local.eq(true))

--- a/plume-models/src/instance.rs
+++ b/plume-models/src/instance.rs
@@ -42,6 +42,7 @@ pub struct NewInstance {
 
 lazy_static! {
     static ref LOCAL_INSTANCE: RwLock<Option<Instance>> = RwLock::new(None);
+    static ref INSTANCE_USER: RwLock<Option<User>> = RwLock::new(None);
 }
 
 impl Instance {
@@ -55,6 +56,14 @@ impl Instance {
             .unwrap()
             .clone()
             .ok_or(Error::NotFound)
+    }
+
+    pub fn set_local_user(u: User) {
+        INSTANCE_USER.write().unwrap().replace(u);
+    }
+
+    pub fn get_local_user() -> Result<User> {
+        INSTANCE_USER.read().unwrap().clone().ok_or(Error::NotFound)
     }
 
     pub fn get_local_uncached(conn: &Connection) -> Result<Instance> {

--- a/plume-models/src/schema.rs
+++ b/plume-models/src/schema.rs
@@ -29,7 +29,6 @@ table! {
         is_owner -> Bool,
     }
 }
-
 table! {
     blogs (id) {
         id -> Int4,


### PR DESCRIPTION
Many activitypub servers are starting to enable Mastodon style authorized fetch for security reasons. As plume does not sign the user fetches, this means it is not possible to fetch actor information from these servers 

The current solution is rather hacky, but it is the best we can figure out without more input and guidance. The ideal solution is to have a quasi actor that can sign these requests and be transparent to the user. As of now it merely fetches the first local user that comes to hand and signs the request with their information.