### PR TITLE
Add missing dep on clang needed for crate builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     make \
     openssl \
-    libssl-dev
+    libssl-dev \
+    clang
 
 WORKDIR /scratch
 COPY script/wasm-deps.sh .


### PR DESCRIPTION
clang is now needed for the latest set of crate dependencies in plume. This patch adds the dependency to the main Dockerfile

Tested on arm64v8 builds. Should fix up all other builds as well.