### PR TITLE
Add warning for missing documentation

### DIFF
--- a/plume-api/src/lib.rs
+++ b/plume-api/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_docs)]
+
 #[macro_use]
 extern crate serde_derive;
 

--- a/plume-common/src/lib.rs
+++ b/plume-common/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 #![feature(associated_type_defaults)]
 
 #[macro_use]

--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"]
 #![feature(decl_macro, proc_macro_hygiene, try_trait)]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate gettext_macros;

--- a/plume-macro/src/lib.rs
+++ b/plume-macro/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "128"]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate quote;

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(try_trait)]
 #![feature(never_type)]
 #![feature(proc_macro_hygiene)]
+#![warn(missing_docs)]
 
 #[macro_use]
 extern crate diesel;


### PR DESCRIPTION
To force us to document our code.

I didn't added it to binaries (`src/` and `plume-cli/` because it didn't really made sense for them IMO), but I can.

Also, to keep this PR small, I propose that we slowly document each function as we modify them in other PRs. Does it seem reasonable to you?