### PR TITLE
snap: Fix build process for Tier 2 platforms

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,21 +31,20 @@ parts:
       - pkg-config
       - libsqlite3-dev
       - gettext
-      - libclang-8-dev
-      - on arm64,armhf,ppc64el,s390x:
-        - lld-8
+      - libclang-9-dev
+      - lld-9
     override-build: |
       snapcraftctl set-version $(git describe --tags)
       export PATH=$PATH:$HOME/.cargo/bin
-      rustup install stable
+      rustup install --force --profile=minimal stable
       cargo +stable install --force cargo-web
 
       # Only Tier 1 Rust platforms get rust-lld
       # On the others (arm64, armhf, powerpc64, s390x) fall back to using
       # the system LLD we've installed earlier.
       case ${SNAPCRAFT_ARCH_TRIPLET} in \
-        aarch64-linux-gnu|arm-linux-gnueabihf|powerpc64-linux-gnu|s390x-linux-gnu) \
-          RUSTFLAGS="-C linker=lld-8" cargo web deploy -p plume-front --release \
+        aarch64-linux-gnu|arm-linux-gnueabihf|powerpc64le-linux-gnu|s390x-linux-gnu) \
+          RUSTFLAGS="-C linker=lld-9" cargo web deploy -p plume-front --release \
           ;; \
         *) \
           cargo web deploy -p plume-front --release \


### PR DESCRIPTION
Unfortunately this only actually *fixes* the build for arm64;
it seems that we hit various bugs in Rust on ppc64 and armhf.