### PR TITLE
Fixed #734 , passowrds are now hidden on the remote_interact pages

### DIFF
--- a/templates/remote_interact_base.rs.html
+++ b/templates/remote_interact_base.rs.html
@@ -25,6 +25,7 @@
 	    			.default(login_form.password)
 	    			.error(&login_errs)
 	    			.set_prop("minlength", 1)
+				.input_type("password")
 	    			.html(ctx.1))
 		        <input type="submit" value="@i18n!(ctx.1, "Log in")" />
 	    	</form>

--- a/templates/remote_interact_base.rs.html
+++ b/templates/remote_interact_base.rs.html
@@ -25,7 +25,7 @@
 	    			.default(login_form.password)
 	    			.error(&login_errs)
 	    			.set_prop("minlength", 1)
-				.input_type("password")
+				    .input_type("password")
 	    			.html(ctx.1))
 		        <input type="submit" value="@i18n!(ctx.1, "Log in")" />
 	    	</form>


### PR DESCRIPTION
This is a quick fix to remove visible passwords on the remote_interact pages.