### PR TITLE
Fix #701 Preferable default theme

### DIFF
--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -54,6 +54,7 @@ pub enum Role {
 }
 
 #[derive(Queryable, Identifiable, Clone, Debug, AsChangeset)]
+#[changeset_options(treat_none_as_null="true")]
 pub struct User {
     pub id: i32,
     pub username: String,

--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -54,7 +54,7 @@ pub enum Role {
 }
 
 #[derive(Queryable, Identifiable, Clone, Debug, AsChangeset)]
-#[changeset_options(treat_none_as_null="true")]
+#[changeset_options(treat_none_as_null = "true")]
 pub struct User {
     pub id: i32,
     pub username: String,

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -399,7 +399,7 @@ pub fn update(
         )
         .0,
     );
-    user.preferred_theme = form.theme.clone();
+    user.preferred_theme = form.theme.clone().and_then(|t| if &t == "" { None } else { Some(t) });
     user.hide_custom_css = form.hide_custom_css;
     let _: User = user.save_changes(&*conn).map_err(Error::from)?;
 

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -399,7 +399,10 @@ pub fn update(
         )
         .0,
     );
-    user.preferred_theme = form.theme.clone().and_then(|t| if &t == "" { None } else { Some(t) });
+    user.preferred_theme = form
+        .theme
+        .clone()
+        .and_then(|t| if &t == "" { None } else { Some(t) });
     user.hide_custom_css = form.hide_custom_css;
     let _: User = user.save_changes(&*conn).map_err(Error::from)?;
 


### PR DESCRIPTION
This patch fixes #701 .

The issue occurs because form value of `email` is empty string `""` when user selects "Default theme" and it is set as preferred theme name. There's no theme named `""`, so any theme is not applied. By setting `NULL` to `users.preferred_theme` when "Default theme" is selected, instance theme is used as the user's preferred theme.

I used Diesel's `#[changeset_options(treat_none_as_null="true")]` attribute on `User` model. This may not be preferred but `save_changes` doesn't have option to set `NULL` sometimes and keep current value otherwise(See http://diesel.rs/guides/all-about-updates/ . It says "Diesel doesn't currently provide a way to explicitly assign a field to its default value"). This is the reason why I used that attribute, but it may have too wide inpact. Could you consider?
