### PR TITLE
Build app and pot files before upload pos to Crowdin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,7 @@ jobs:
     steps:
     - restore_env:
         cache: none
+    - run: cargo build
     - run: crowdin upload -b master
 
 workflows:


### PR DESCRIPTION
so that `crowdin` command recognize updated `*.pot` files.

See #747 for details.