### PR TITLE
Fixes #757 Allow Unicode hashtags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,6 +2213,7 @@ dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/plume-common/Cargo.toml
+++ b/plume-common/Cargo.toml
@@ -22,6 +22,7 @@ serde_json = "1.0"
 shrinkwraprs = "0.2.1"
 syntect = "3.3"
 tokio = "0.1.22"
+regex-syntax = { version = "0.6.17", default-features = false, features = ["unicode-perl"] }
 
 [dependencies.chrono]
 features = ["serde"]

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -1,6 +1,7 @@
 use heck::CamelCase;
 use openssl::rand::rand_bytes;
 use pulldown_cmark::{html, Event, Options, Parser, Tag};
+use regex_syntax::is_word_character;
 use rocket::{
     http::uri::Uri,
     response::{Flash, Redirect},
@@ -9,7 +10,6 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use syntect::html::ClassedHTMLGenerator;
 use syntect::parsing::SyntaxSet;
-use regex_syntax::is_word_character;
 
 /// Generates an hexadecimal representation of 32 bytes of random data
 pub fn random_hex() -> String {

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use syntect::html::ClassedHTMLGenerator;
 use syntect::parsing::SyntaxSet;
+use regex_syntax::is_word_character;
 
 /// Generates an hexadecimal representation of 32 bytes of random data
 pub fn random_hex() -> String {
@@ -269,7 +270,7 @@ pub fn md_to_html<'a>(
                                 }
                             }
                             State::Hashtag => {
-                                let char_matches = c.is_alphanumeric() || "-_".contains(c);
+                                let char_matches = c == '-' || is_word_character(c);
                                 if char_matches && (n < (txt.chars().count() - 1)) {
                                     text_acc.push(c);
                                     (events, State::Hashtag, text_acc, n + 1, mentions, hashtags)

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -424,6 +424,7 @@ mod tests {
             ("with some punctuation #test!", vec!["test"]),
             (" #spaces     ", vec!["spaces"]),
             ("not_a#hashtag", vec![]),
+            ("#نرم‌افزار_آزاد", vec!["نرم‌افزار_آزاد"]),
         ];
 
         for (md, mentions) in tests {


### PR DESCRIPTION
Hi,

This patch fixes #757 .

I verified [regex-syntax][] crate by [minimum code][].

The result is: [![Screenshot from Gyazo](https://gyazo.com/4dccd2cdb53cc97d37a599b1c4ca1af7/raw)](https://gyazo.com/4dccd2cdb53cc97d37a599b1c4ca1af7)

After this patch is merged, you need visit edit panel and save the article again to recompile Markdown to HTML.

[regex-syntax]: https://github.com/rust-lang/regex/tree/master/regex-syntax
[minimum code]: https://gitlab.com/KitaitiMakoto/try-unicode-syntax/-/tree/master