### PR TITLE
Fixes #755 Fix user subscription URI so that plume::routes:interact accept it

### DIFF
--- a/plume-models/src/users.rs
+++ b/plume-models/src/users.rs
@@ -760,7 +760,7 @@ impl User {
                     mime_type: None,
                     href: None,
                     template: Some(format!(
-                        "https://{}/remote_interact?{{uri}}",
+                        "https://{}/remote_interact?target={{uri}}",
                         self.get_instance(conn)?.public_domain
                     )),
                 },


### PR DESCRIPTION
Now Plume users can like and boost posts on other instances.