### PR TITLE
Keep atmarks and hashes in link

### DIFF
--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -414,6 +414,7 @@ mod tests {
             ("not_a@mention", vec![]),
             ("`@helo`", vec![]),
             ("```\n@hello\n```", vec![]),
+            ("[@atmark in link](https://example.org/)", vec![]),
         ];
 
         for (md, mentions) in tests {

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -431,6 +431,7 @@ mod tests {
             (" #spaces     ", vec!["spaces"]),
             ("not_a#hashtag", vec![]),
             ("#نرم‌افزار_آزاد", vec!["نرم‌افزار_آزاد"]),
+            ("[#hash in link](https://example.org/)", vec![]),
         ];
 
         for (md, mentions) in tests {

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -239,6 +239,14 @@ pub fn md_to_html<'a>(
                 ctx.in_code = false;
                 Some((vec![evt], vec![], vec![]))
             }
+            Event::Start(Tag::Link(_, _)) => {
+                ctx.in_link = true;
+                Some((vec![evt], vec![], vec![]))
+            }
+            Event::End(Tag::Link(_, _)) => {
+                ctx.in_link = false;
+                Some((vec![evt], vec![], vec![]))
+            }
             Event::Text(txt) => {
                 let (evts, _, _, _, new_mentions, new_hashtags) = txt.chars().fold(
                     (vec![], State::Ready, String::new(), 0, vec![], vec![]),
@@ -317,7 +325,7 @@ pub fn md_to_html<'a>(
                                         mentions,
                                         hashtags,
                                     )
-                                } else if !ctx.in_code && c == '#' {
+                                } else if !ctx.in_code && !ctx.in_link && c == '#' {
                                     events.push(Event::Text(text_acc.into()));
                                     (
                                         events,

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -204,6 +204,7 @@ fn process_image<'a, 'b>(
 #[derive(Default, Debug)]
 struct DocumentContext {
     in_code: bool,
+    in_link: bool,
 }
 
 /// Returns (HTML, mentions, hashtags)

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -315,7 +315,7 @@ pub fn md_to_html<'a>(
                                 }
                             }
                             State::Ready => {
-                                if !ctx.in_code && c == '@' {
+                                if !ctx.in_code && !ctx.in_link && c == '@' {
                                     events.push(Event::Text(text_acc.into()));
                                     (
                                         events,

--- a/plume-common/src/utils.rs
+++ b/plume-common/src/utils.rs
@@ -201,7 +201,7 @@ fn process_image<'a, 'b>(
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct DocumentContext {
     in_code: bool,
 }


### PR DESCRIPTION
I found hashes in link text like `[Fixes #745 Use plural form for 0 in French](https://github.com/Plume-org/Plume/pull/760)` are treated as hashtags and breaks the link. I think this is not preferable. How do you think?