### PR TITLE
remove dependency on runtime-fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,7 +2167,6 @@ dependencies = [
  "rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rsass 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ructe 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "runtime-fmt 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2792,14 +2791,6 @@ dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "runtime-fmt"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4223,7 +4214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rpassword 4.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 "checksum rsass 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4534cc03040beacd2668621815f26fe57e5b7cfe085790f98e5e87c1612316"
 "checksum ructe 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c85620b8046f88a870d93d90fa56904dec76cc79139bfcc22e71e87f0cd2169f"
-"checksum runtime-fmt 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "703425f78450961e590726ac24d823e6dc2340dc18282cf0cb6a417b26ca2ce8"
 "checksum rust-stemmers 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rocket = "0.4.2"
 rocket_contrib = { version = "0.4.2", features = ["json"] }
 rocket_i18n = { git = "https://github.com/Plume-org/rocket_i18n", rev = "e922afa7c366038b3433278c03b1456b346074f2" }
 rpassword = "4.0"
-runtime-fmt = "0.4.0"
 scheduled-thread-pool = "0.2.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@ extern crate gettext_macros;
 #[macro_use]
 extern crate rocket;
 #[macro_use]
-extern crate runtime_fmt;
-#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate validator_derive;

--- a/src/routes/posts.rs
+++ b/src/routes/posts.rs
@@ -643,7 +643,7 @@ pub fn remote_interact_post(
         .and_then(|blog| Post::find_by_slug(&rockets.conn, &slug, blog.id))?;
     if let Some(uri) = User::fetch_remote_interact_uri(&remote.remote)
         .ok()
-        .and_then(|uri| rt_format!(uri, uri = target.ap_url).ok())
+        .map(|uri| uri.replace("{uri}", &target.ap_url))
     {
         Ok(Redirect::to(uri).into())
     } else {

--- a/src/routes/user.rs
+++ b/src/routes/user.rs
@@ -201,15 +201,14 @@ pub fn follow_not_connected(
         if let Some(uri) = User::fetch_remote_interact_uri(&remote_form)
             .ok()
             .and_then(|uri| {
-                rt_format!(
-                    uri,
-                    uri = format!(
+                Some(uri.replace(
+                    "{uri}",
+                    &format!(
                         "{}@{}",
                         target.fqn,
                         target.get_instance(&rockets.conn).ok()?.public_domain
-                    )
-                )
-                .ok()
+                    ),
+                ))
             })
         {
             Ok(Redirect::to(uri).into())


### PR DESCRIPTION
Per the issue, "runtime-fmt uses perma-unstable rust APIs and is
therefore susceptible to breakage".

This replaces the two calls to rt_format! with .replace() and drops the
dependency.

Fixes #769