### PR TITLE
[WIP] [PoC] '&' -> '&mut'

### DIFF
--- a/plume-common/src/activity_pub/inbox.rs
+++ b/plume-common/src/activity_pub/inbox.rs
@@ -86,7 +86,7 @@ where
     /// - the context to be passed to each handler.
     /// - the activity
     /// - the reason it has not been handled yet
-    NotHandled(&'a C, serde_json::Value, InboxError<E>),
+    NotHandled(&'a mut C, serde_json::Value, InboxError<E>),
 
     /// A matching handler have been found but failed
     ///
@@ -139,16 +139,16 @@ where
     ///
     /// - `ctx`: the context to pass to each handler
     /// - `json`: the JSON representation of the incoming activity
-    pub fn handle(ctx: &'a C, json: serde_json::Value) -> Inbox<'a, C, E, R> {
+    pub fn handle(ctx: &'a mut C, json: serde_json::Value) -> Inbox<'a, C, E, R> {
         Inbox::NotHandled(ctx, json, InboxError::NoMatch)
     }
 
     /// Registers an handler on this Inbox.
     pub fn with<A, V, M>(self) -> Inbox<'a, C, E, R>
     where
-        A: AsActor<&'a C> + FromId<C, Error = E>,
+        A: AsActor<&'a mut C> + FromId<C, Error = E>,
         V: activitypub::Activity,
-        M: AsObject<A, V, &'a C, Error = E> + FromId<C, Error = E>,
+        M: AsObject<A, V, &'a mut C, Error = E> + FromId<C, Error = E>,
         M::Output: Into<R>,
     {
         if let Inbox::NotHandled(ctx, mut act, e) = self {
@@ -264,7 +264,7 @@ pub trait FromId<C>: Sized {
     /// - `object`: optional object that will be used if the object was not found in the database
     ///   If absent, the ID will be dereferenced.
     fn from_id(
-        ctx: &C,
+        ctx: &mut C,
         id: &str,
         object: Option<Self::Object>,
     ) -> Result<Self, (Option<serde_json::Value>, Self::Error)> {
@@ -308,10 +308,10 @@ pub trait FromId<C>: Sized {
     }
 
     /// Builds a `Self` from its ActivityPub representation
-    fn from_activity(ctx: &C, activity: Self::Object) -> Result<Self, Self::Error>;
+    fn from_activity(ctx: &mut C, activity: Self::Object) -> Result<Self, Self::Error>;
 
     /// Tries to find a `Self` with a given ID (`id`), using `ctx` (a database)
-    fn from_db(ctx: &C, id: &str) -> Result<Self, Self::Error>;
+    fn from_db(ctx: &mut C, id: &str) -> Result<Self, Self::Error>;
 }
 
 /// Should be implemented by anything representing an ActivityPub actor.

--- a/plume-models/src/blogs.rs
+++ b/plume-models/src/blogs.rs
@@ -132,7 +132,7 @@ impl Blog {
             .map_err(Error::from)
     }
 
-    pub async fn find_by_fqn(c: &PlumeRocket, fqn: &str) -> Result<Blog> {
+    pub async fn find_by_fqn(c: &mut PlumeRocket, fqn: &str) -> Result<Blog> {
         let from_db = blogs::table
             .filter(blogs::fqn.eq(fqn))
             .first(&*c.conn)
@@ -144,7 +144,7 @@ impl Blog {
         }
     }
 
-    async fn fetch_from_webfinger(c: &PlumeRocket, acct: &str) -> Result<Blog> {
+    async fn fetch_from_webfinger(c: &mut PlumeRocket, acct: &str) -> Result<Blog> {
         resolve_with_prefix(Prefix::Group, acct.to_owned(), true)
             .await?
             .links
@@ -340,11 +340,11 @@ impl FromId<PlumeRocket> for Blog {
     type Error = Error;
     type Object = CustomGroup;
 
-    fn from_db(c: &PlumeRocket, id: &str) -> Result<Self> {
+    fn from_db(c: &mut PlumeRocket, id: &str) -> Result<Self> {
         Self::find_by_ap_url(&c.conn, id)
     }
 
-    fn from_activity(c: &PlumeRocket, acct: CustomGroup) -> Result<Self> {
+    fn from_activity(c: &mut PlumeRocket, acct: CustomGroup) -> Result<Self> {
         let url = Url::parse(&acct.object.object_props.id_string()?)?;
         let inst = url.host_str()?;
         let instance = Instance::find_by_domain(&c.conn, inst).or_else(|_| {
@@ -436,7 +436,7 @@ impl FromId<PlumeRocket> for Blog {
     }
 }
 
-impl AsActor<&PlumeRocket> for Blog {
+impl AsActor<&mut PlumeRocket> for Blog {
     fn get_inbox_url(&self) -> String {
         self.inbox_url.clone()
     }

--- a/plume-models/src/comments.rs
+++ b/plume-models/src/comments.rs
@@ -105,7 +105,7 @@ impl Comment {
                 .unwrap_or(false)
     }
 
-    pub async fn to_activity(&self, c: &PlumeRocket) -> Result<Note> {
+    pub async fn to_activity(&self, c: &mut PlumeRocket) -> Result<Note> {
         let author = User::get(&c.conn, self.author_id)?;
         let (html, mentions, _hashtags) = utils::md_to_html(
             self.content.get().as_ref(),
@@ -140,7 +140,7 @@ impl Comment {
         Ok(note)
     }
 
-    pub async fn create_activity(&self, c: &PlumeRocket) -> Result<Create> {
+    pub async fn create_activity(&self, c: &mut PlumeRocket) -> Result<Create> {
         let author = User::get(&c.conn, self.author_id)?;
 
         let note = self.to_activity(c).await?;
@@ -198,11 +198,11 @@ impl FromId<PlumeRocket> for Comment {
     type Error = Error;
     type Object = Note;
 
-    fn from_db(c: &PlumeRocket, id: &str) -> Result<Self> {
+    fn from_db(c: &mut PlumeRocket, id: &str) -> Result<Self> {
         Self::find_by_ap_url(&c.conn, id)
     }
 
-    fn from_activity(c: &PlumeRocket, note: Note) -> Result<Self> {
+    fn from_activity(c: &mut PlumeRocket, note: Note) -> Result<Self> {
         let conn = &*c.conn;
         let comm = {
             let previous_url = note.object_props.in_reply_to.as_ref()?.as_str()?;
@@ -322,21 +322,21 @@ impl FromId<PlumeRocket> for Comment {
     }
 }
 
-impl AsObject<User, Create, &PlumeRocket> for Comment {
+impl AsObject<User, Create, &mut PlumeRocket> for Comment {
     type Error = Error;
     type Output = Self;
 
-    fn activity(self, _c: &PlumeRocket, _actor: User, _id: &str) -> Result<Self> {
+    fn activity(self, _c: &mut PlumeRocket, _actor: User, _id: &str) -> Result<Self> {
         // The actual creation takes place in the FromId impl
         Ok(self)
     }
 }
 
-impl AsObject<User, Delete, &PlumeRocket> for Comment {
+impl AsObject<User, Delete, &mut PlumeRocket> for Comment {
     type Error = Error;
     type Output = ();
 
-    fn activity(self, c: &PlumeRocket, actor: User, _id: &str) -> Result<()> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, _id: &str) -> Result<()> {
         if self.author_id != actor.id {
             return Err(Error::Unauthorized);
         }

--- a/plume-models/src/follows.rs
+++ b/plume-models/src/follows.rs
@@ -136,11 +136,11 @@ impl Follow {
     }
 }
 
-impl AsObject<User, FollowAct, &PlumeRocket> for User {
+impl AsObject<User, FollowAct, &mut PlumeRocket> for User {
     type Error = Error;
     type Output = Follow;
 
-    fn activity(self, c: &PlumeRocket, actor: User, id: &str) -> Result<Follow> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, id: &str) -> Result<Follow> {
         // Mastodon (at least) requires the full Follow object when accepting it,
         // so we rebuilt it here
         let mut follow = FollowAct::default();
@@ -156,11 +156,11 @@ impl FromId<PlumeRocket> for Follow {
     type Error = Error;
     type Object = FollowAct;
 
-    fn from_db(c: &PlumeRocket, id: &str) -> Result<Self> {
+    fn from_db(c: &mut PlumeRocket, id: &str) -> Result<Self> {
         Follow::find_by_ap_url(&c.conn, id)
     }
 
-    fn from_activity(c: &PlumeRocket, follow: FollowAct) -> Result<Self> {
+    fn from_activity(c: &mut PlumeRocket, follow: FollowAct) -> Result<Self> {
         let actor =
             User::from_id(c, &follow.follow_props.actor_link::<Id>()?, None).map_err(|(_, e)| e)?;
 
@@ -170,11 +170,11 @@ impl FromId<PlumeRocket> for Follow {
     }
 }
 
-impl AsObject<User, Undo, &PlumeRocket> for Follow {
+impl AsObject<User, Undo, &mut PlumeRocket> for Follow {
     type Error = Error;
     type Output = ();
 
-    fn activity(self, c: &PlumeRocket, actor: User, _id: &str) -> Result<()> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, _id: &str) -> Result<()> {
         let conn = &*c.conn;
         if self.follower_id == actor.id {
             diesel::delete(&self).execute(conn)?;

--- a/plume-models/src/inbox.rs
+++ b/plume-models/src/inbox.rs
@@ -45,7 +45,7 @@ impl_into_inbox_result! {
     Reshare => Reshared
 }
 
-pub fn inbox(ctx: &PlumeRocket, act: serde_json::Value) -> Result<InboxResult, Error> {
+pub fn inbox(ctx: &mut PlumeRocket, act: serde_json::Value) -> Result<InboxResult, Error> {
     Inbox::handle(ctx, act)
         .with::<User, Announce, Post>()
         .with::<User, Create, Comment>()
@@ -72,7 +72,7 @@ pub(crate) mod tests {
     use diesel::Connection;
 
     pub fn fill_database(
-        rockets: &PlumeRocket,
+        rockets: &mut PlumeRocket,
     ) -> (
         Vec<crate::posts::Post>,
         Vec<crate::users::User>,

--- a/plume-models/src/likes.rs
+++ b/plume-models/src/likes.rs
@@ -83,11 +83,11 @@ impl Like {
     }
 }
 
-impl AsObject<User, activity::Like, &PlumeRocket> for Post {
+impl AsObject<User, activity::Like, &mut PlumeRocket> for Post {
     type Error = Error;
     type Output = Like;
 
-    fn activity(self, c: &PlumeRocket, actor: User, id: &str) -> Result<Like> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, id: &str) -> Result<Like> {
         let res = Like::insert(
             &c.conn,
             NewLike {
@@ -107,11 +107,11 @@ impl FromId<PlumeRocket> for Like {
     type Error = Error;
     type Object = activity::Like;
 
-    fn from_db(c: &PlumeRocket, id: &str) -> Result<Self> {
+    fn from_db(c: &mut PlumeRocket, id: &str) -> Result<Self> {
         Like::find_by_ap_url(&c.conn, id)
     }
 
-    fn from_activity(c: &PlumeRocket, act: activity::Like) -> Result<Self> {
+    fn from_activity(c: &mut PlumeRocket, act: activity::Like) -> Result<Self> {
         let res = Like::insert(
             &c.conn,
             NewLike {
@@ -129,11 +129,11 @@ impl FromId<PlumeRocket> for Like {
     }
 }
 
-impl AsObject<User, activity::Undo, &PlumeRocket> for Like {
+impl AsObject<User, activity::Undo, &mut PlumeRocket> for Like {
     type Error = Error;
     type Output = ();
 
-    fn activity(self, c: &PlumeRocket, actor: User, _id: &str) -> Result<()> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, _id: &str) -> Result<()> {
         let conn = &*c.conn;
         if actor.id == self.user_id {
             diesel::delete(&self).execute(conn)?;

--- a/plume-models/src/mentions.rs
+++ b/plume-models/src/mentions.rs
@@ -52,7 +52,7 @@ impl Mention {
         }
     }
 
-    pub async fn build_activity(c: &PlumeRocket, ment: &str) -> Result<link::Mention> {
+    pub async fn build_activity(c: &mut PlumeRocket, ment: &str) -> Result<link::Mention> {
         let user = User::find_by_fqn(c, ment).await?;
         let mut mention = link::Mention::default();
         mention.link_props.set_href_string(user.ap_url)?;

--- a/plume-models/src/reshares.rs
+++ b/plume-models/src/reshares.rs
@@ -107,11 +107,11 @@ impl Reshare {
     }
 }
 
-impl AsObject<User, Announce, &PlumeRocket> for Post {
+impl AsObject<User, Announce, &mut PlumeRocket> for Post {
     type Error = Error;
     type Output = Reshare;
 
-    fn activity(self, c: &PlumeRocket, actor: User, id: &str) -> Result<Reshare> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, id: &str) -> Result<Reshare> {
         let conn = &*c.conn;
         let reshare = Reshare::insert(
             conn,
@@ -132,11 +132,11 @@ impl FromId<PlumeRocket> for Reshare {
     type Error = Error;
     type Object = Announce;
 
-    fn from_db(c: &PlumeRocket, id: &str) -> Result<Self> {
+    fn from_db(c: &mut PlumeRocket, id: &str) -> Result<Self> {
         Reshare::find_by_ap_url(&c.conn, id)
     }
 
-    fn from_activity(c: &PlumeRocket, act: Announce) -> Result<Self> {
+    fn from_activity(c: &mut PlumeRocket, act: Announce) -> Result<Self> {
         let res = Reshare::insert(
             &c.conn,
             NewReshare {
@@ -154,11 +154,11 @@ impl FromId<PlumeRocket> for Reshare {
     }
 }
 
-impl AsObject<User, Undo, &PlumeRocket> for Reshare {
+impl AsObject<User, Undo, &mut PlumeRocket> for Reshare {
     type Error = Error;
     type Output = ();
 
-    fn activity(self, c: &PlumeRocket, actor: User, _id: &str) -> Result<()> {
+    fn activity(self, c: &mut PlumeRocket, actor: User, _id: &str) -> Result<()> {
         let conn = &*c.conn;
         if actor.id == self.user_id {
             diesel::delete(&self).execute(conn)?;

--- a/plume-models/src/timeline/mod.rs
+++ b/plume-models/src/timeline/mod.rs
@@ -208,7 +208,7 @@ impl Timeline {
             .map_err(Error::from)
     }
 
-    pub fn add_to_all_timelines(rocket: &PlumeRocket, post: &Post, kind: Kind<'_>) -> Result<()> {
+    pub fn add_to_all_timelines(rocket: &mut PlumeRocket, post: &Post, kind: Kind<'_>) -> Result<()> {
         let timelines = timeline_definition::table
             .load::<Self>(rocket.conn.deref())
             .map_err(Error::from)?;
@@ -231,7 +231,7 @@ impl Timeline {
         Ok(())
     }
 
-    pub fn matches(&self, rocket: &PlumeRocket, post: &Post, kind: Kind<'_>) -> Result<bool> {
+    pub fn matches(&self, rocket: &mut PlumeRocket, post: &Post, kind: Kind<'_>) -> Result<bool> {
         let query = TimelineQuery::parse(&self.query)?;
         query.matches(rocket, self, post, kind)
     }

--- a/plume-models/src/timeline/query.rs
+++ b/plume-models/src/timeline/query.rs
@@ -162,7 +162,7 @@ enum TQ<'a> {
 impl<'a> TQ<'a> {
     fn matches(
         &self,
-        rocket: &PlumeRocket,
+        rocket: &mut PlumeRocket,
         timeline: &Timeline,
         post: &Post,
         kind: Kind<'_>,
@@ -207,7 +207,7 @@ enum Arg<'a> {
 impl<'a> Arg<'a> {
     pub fn matches(
         &self,
-        rocket: &PlumeRocket,
+        rocket: &mut PlumeRocket,
         timeline: &Timeline,
         post: &Post,
         kind: Kind<'_>,
@@ -232,7 +232,7 @@ enum WithList {
 impl WithList {
     pub fn matches(
         &self,
-        rocket: &PlumeRocket,
+        rocket: &mut PlumeRocket,
         timeline: &Timeline,
         post: &Post,
         list: &List<'_>,
@@ -391,7 +391,7 @@ enum Bool {
 impl Bool {
     pub fn matches(
         &self,
-        rocket: &PlumeRocket,
+        rocket: &mut PlumeRocket,
         timeline: &Timeline,
         post: &Post,
         kind: Kind<'_>,
@@ -662,7 +662,7 @@ impl<'a> TimelineQuery<'a> {
 
     pub fn matches(
         &self,
-        rocket: &PlumeRocket,
+        rocket: &mut PlumeRocket,
         timeline: &Timeline,
         post: &Post,
         kind: Kind<'_>,


### PR DESCRIPTION
This is a (incomplete) proof of concept of a possible workaround for `Sync` issues that appear in `async` code.

Roughly, the issue is this:

* Route handler futures must be `Send`. This requirement comes from Rocket, and would be nontrivial and/or undesirable to change in Rocket.
* Handlers have an `&PlumeRocket` or an `&Connection` held across an `await` point
* Therefore, `&PlumeRocket` / `&Connection` must be `Send`
*  `&T: Send` iff `T: Sync`, so `PlumeRocket` / `Connection` must be `Sync`
* `PlumeRocket` contains a `Connection`, and `Connection` contains a diesel `PgConnection`, which is not `Sync`.

The approach demonstrated here is to change every `&PlumeRocket` or `&Connection` to an `&mut PlumeRocket` or `&mut Connection`. `&mut T` is `Send` if `T` is `Send`, so the problem is eliminated:

* Route handler futures must be `Send`.
* Handlers have an `&mut PlumeRocket` or an `&mut Connection` held across an `await` point
* Therefore, `&mut PlumeRocket` / `&mut Connection` must be `Send`
*  **`&mut T: Send` iff `T: Send`**, so `PlumeRocket` / `Connection` must be **`Send`**
* `PlumeRocket` contains a `Connection`, and `Connection` contains a diesel `PgConnection`, which **is `Send`.**

## Downsides
* In theory `&PlumeRocket` *could* allow more work to be done in parallel, at least in the future. It does not look like that is currently the case, since every call to the database blocks anyway.
* This change is pervasive - it reaches all the way to `FromId` and `Inbox`. I know relatively little about the overall structure of this code, so this could be incorrect or inconvenient in ways I don't know about!
* Many of the remaining errors are caused by or made worse by the `&` -> `&mut` change. A different solution that keeps `&` in more places would be easier to work with overall.
* This approach does not address the problem of making blocking database calls inside `async` fns, which can cause issues ranging from degraded performance to deadlocks.

## Alternatives
* Put a `Mutex` around the `Connection` somewhere. Uncontended mutexes (which this one should be) are not a *huge* performance concern, but `Mutex` may be at least as or more unwieldy than this solution throughout the code.
* Replace or wrap `Connection` with an API like `conn.run(|c| Post::load(&c)).await`, where `run` handles the synchronization. This has similar tradeoffs to a `Mutex`, is probably the most inconvenient option in terms of overall code changes, and is also a significant chunk of new code to write and debug. However, it has the advantage of being capable of fixing the blocking-in-`async`-fn problem.