### PR TITLE
Don't show boosts and likes for "all" and "local" in timelines

### DIFF
--- a/plume-models/src/timeline/query.rs
+++ b/plume-models/src/timeline/query.rs
@@ -406,8 +406,8 @@ impl Bool {
                 }
             }
             Bool::HasCover => Ok(post.cover_id.is_some()),
-            Bool::Local => Ok(post.get_blog(&rocket.conn)?.is_local()),
-            Bool::All => Ok(true),
+            Bool::Local => Ok(post.get_blog(&rocket.conn)?.is_local() && kind == Kind::Original),
+            Bool::All => Ok(kind == Kind::Original),
         }
     }
 }


### PR DESCRIPTION
The fix was quite easy actually :sweat_smile: I think it is just that it wasn't clear enough for us that `local`/`all` shouldn't match boosts and likes, but only new posts.

Fixes #711