### PR TITLE
Force interface language by config file

### DIFF
--- a/plume-front/src/main.rs
+++ b/plume-front/src/main.rs
@@ -46,6 +46,9 @@ lazy_static! {
         let lang = js! { return navigator.language }.into_string().unwrap();
         let lang = lang.splitn(2, '-').next().unwrap_or("en");
 
+        // Force a language (Add .env setting)
+        //let lang = "fa"; ???
+
         let english_position = catalogs
             .iter()
             .position(|(language_code, _)| *language_code == "en")


### PR DESCRIPTION
As explained in #785, trying to force the language interface which specified in `.env` file.

I tried the commented code below and re-compiled the front, but nothing happened. Since I didn't find any other piece which gets browser language, I assume my method of recompilation is flawed. (Only do `cargo web deploy -p plume-front --release`)

So I made this WIP PR as @igalic suggested. 😁