### PR TITLE
plume-model: refactor Searcher to have its own DbPool

### DIFF
--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -304,6 +304,10 @@ mod tests {
         db_conn::DbConn((*DB_POOL).get().unwrap())
     }
 
+    pub fn pool<'a>() -> db_conn::DbPool {
+        (*DB_POOL).clone()
+    }
+
     lazy_static! {
         static ref DB_POOL: db_conn::DbPool = {
             let pool = db_conn::DbPool::builder()

--- a/plume-models/src/lib.rs
+++ b/plume-models/src/lib.rs
@@ -40,6 +40,7 @@ pub enum Error {
     Io(std::io::Error),
     MissingApProperty,
     NotFound,
+    DbPool,
     Request,
     SerDe,
     Search(search::SearcherError),

--- a/plume-models/src/plume_rocket.rs
+++ b/plume-models/src/plume_rocket.rs
@@ -2,7 +2,7 @@ pub use self::module::PlumeRocket;
 
 #[cfg(not(test))]
 mod module {
-    use crate::{db_conn::DbConn, search, users};
+    use crate::{db_conn::DbConn, users};
     use rocket::{
         request::{self, FlashMessage, FromRequest, Request},
         Outcome, State,
@@ -15,7 +15,6 @@ mod module {
         pub conn: DbConn,
         pub intl: rocket_i18n::I18n,
         pub user: Option<users::User>,
-        pub searcher: Arc<search::Searcher>,
         pub worker: Arc<ScheduledThreadPool>,
         pub flash_msg: Option<(String, String)>,
     }
@@ -28,7 +27,6 @@ mod module {
             let intl = request.guard::<rocket_i18n::I18n>()?;
             let user = request.guard::<users::User>().succeeded();
             let worker = request.guard::<'_, State<'_, Arc<ScheduledThreadPool>>>()?;
-            let searcher = request.guard::<'_, State<'_, Arc<search::Searcher>>>()?;
             let flash_msg = request.guard::<FlashMessage<'_, '_>>().succeeded();
             Outcome::Success(PlumeRocket {
                 conn,
@@ -36,7 +34,6 @@ mod module {
                 user,
                 flash_msg: flash_msg.map(|f| (f.name().into(), f.msg().into())),
                 worker: worker.clone(),
-                searcher: searcher.clone(),
             })
         }
     }
@@ -56,7 +53,6 @@ mod module {
     pub struct PlumeRocket {
         pub conn: DbConn,
         pub user: Option<users::User>,
-        pub searcher: Arc<search::Searcher>,
         pub worker: Arc<ScheduledThreadPool>,
     }
 
@@ -67,12 +63,10 @@ mod module {
             let conn = request.guard::<DbConn>()?;
             let user = request.guard::<users::User>().succeeded();
             let worker = request.guard::<'_, State<'_, Arc<ScheduledThreadPool>>>()?;
-            let searcher = request.guard::<'_, State<'_, Arc<search::Searcher>>>()?;
             Outcome::Success(PlumeRocket {
                 conn,
                 user,
                 worker: worker.clone(),
-                searcher: searcher.clone(),
             })
         }
     }

--- a/plume-models/src/posts.rs
+++ b/plume-models/src/posts.rs
@@ -78,14 +78,14 @@ impl Post {
             let _: Post = post.save_changes(conn)?;
         }
 
-        searcher.add_document(conn, &post)?;
+        searcher.add_document(&post)?;
         Ok(post)
     }
 
     pub fn update(&self, conn: &Connection, searcher: &Searcher) -> Result<Self> {
         diesel::update(self).set(self).execute(conn)?;
         let post = Self::get(conn, self.id)?;
-        searcher.update_document(conn, &post)?;
+        searcher.update_document(&post)?;
         Ok(post)
     }
 

--- a/plume-models/src/search/searcher.rs
+++ b/plume-models/src/search/searcher.rs
@@ -5,6 +5,7 @@ use crate::{
 use chrono::{Datelike, Utc};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use itertools::Itertools;
+use rocket::request::{self, FromRequest, Outcome, Request, State};
 use std::{cmp, fs::create_dir_all, io, path::Path, sync::Mutex};
 use tantivy::{
     collector::TopDocs, directory::MmapDirectory, schema::*, Index, IndexReader, IndexWriter,
@@ -371,5 +372,14 @@ Then try to restart Plume
 
     pub fn drop_writer(&self) {
         self.writer.lock().unwrap().take();
+    }
+}
+
+impl<'a, 'r> FromRequest<'a, 'r> for Searcher {
+    type Error = ();
+
+    fn from_request(request: &'a Request<'r>) -> request::Outcome<Searcher, Self::Error> {
+        let searcher = request.guard::<State<'_, Searcher>>()?;
+        Outcome::Success(*searcher.inner())
     }
 }

--- a/plume-models/src/search/searcher.rs
+++ b/plume-models/src/search/searcher.rs
@@ -5,13 +5,7 @@ use crate::{
 use chrono::{Datelike, Utc};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use itertools::Itertools;
-use std::{
-    cmp,
-    fs::create_dir_all,
-    io,
-    path::Path,
-    sync::{Arc, Mutex},
-};
+use std::{cmp, fs::create_dir_all, io, path::Path, sync::Mutex};
 use tantivy::{
     collector::TopDocs, directory::MmapDirectory, schema::*, Index, IndexReader, IndexWriter,
     ReloadPolicy, TantivyError, Term,
@@ -55,7 +49,7 @@ impl Searcher {
     ///
     /// The panic messages are normally explicit enough for a human to
     /// understand how to fix the issue when they see it.
-    pub fn new(db_pool: DbPool) -> Arc<Self> {
+    pub fn new(db_pool: DbPool) -> Self {
         // We try to open the index a first time
         let searcher = match Self::open(
             &CONFIG.search_index,
@@ -131,7 +125,7 @@ Then try to restart Plume
                 e => Err(e).unwrap(),
             },
             Err(_) => panic!("Unexpected error while opening search index"),
-            Ok(s) => Arc::new(s),
+            Ok(s) => s,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,20 +10,10 @@ extern crate serde_json;
 #[macro_use]
 extern crate validator_derive;
 
-use chrono::Utc;
 use clap::App;
-use diesel::r2d2::ConnectionManager;
-use plume_models::{
-    db_conn::{DbPool, PragmaForeignKey},
-    instance::Instance,
-    migrations::IMPORTED_MIGRATIONS,
-    search::{Searcher as UnmanagedSearcher, SearcherError},
-    Connection, Error, CONFIG,
-};
+use plume_models::{db_conn::init_pool, migrations::IMPORTED_MIGRATIONS, search::Searcher, CONFIG};
 use rocket_csrf::CsrfFairingBuilder;
 use scheduled_thread_pool::ScheduledThreadPool;
-use std::fs;
-use std::path::Path;
 use std::process::exit;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -48,26 +38,6 @@ include!(concat!(env!("OUT_DIR"), "/templates.rs"));
 
 compile_i18n!();
 
-/// Initializes a database pool.
-fn init_pool() -> Option<DbPool> {
-    match dotenv::dotenv() {
-        Ok(path) => println!("Configuration read from {}", path.display()),
-        Err(ref e) if e.not_found() => eprintln!("no .env was found"),
-        e => e.map(|_| ()).unwrap(),
-    }
-
-    let manager = ConnectionManager::<Connection>::new(CONFIG.database_url.as_str());
-    let mut builder = DbPool::builder()
-        .connection_customizer(Box::new(PragmaForeignKey))
-        .min_idle(CONFIG.db_min_idle);
-    if let Some(max_size) = CONFIG.db_max_size {
-        builder = builder.max_size(max_size);
-    };
-    let pool = builder.build(manager).ok()?;
-    Instance::cache_local(&pool.get().unwrap());
-    Some(pool)
-}
-
 fn main() {
     App::new("Plume")
         .bin_name("plume")
@@ -82,6 +52,13 @@ and https://docs.joinplu.me/installation/init for more info.
         "#,
         )
         .get_matches();
+
+    match dotenv::dotenv() {
+        Ok(path) => println!("Configuration read from {}", path.display()),
+        Err(ref e) if e.not_found() => eprintln!("no .env was found"),
+        e => e.map(|_| ()).unwrap(),
+    }
+
     let dbpool = init_pool().expect("main: database pool initialization error");
     if IMPORTED_MIGRATIONS
         .is_pending(&dbpool.get().unwrap())
@@ -100,60 +77,8 @@ Then try to restart Plume.
         )
     }
     let workpool = ScheduledThreadPool::with_name("worker {}", num_cpus::get());
-    // we want a fast exit here, so
-    let mut open_searcher =
-        UnmanagedSearcher::open(&CONFIG.search_index, &CONFIG.search_tokenizers);
-    if let Err(Error::Search(SearcherError::InvalidIndexDataError)) = open_searcher {
-        if UnmanagedSearcher::create(&CONFIG.search_index, &CONFIG.search_tokenizers).is_err() {
-            let current_path = Path::new(&CONFIG.search_index);
-            let backup_path = format!("{}.{}", &current_path.display(), Utc::now().timestamp());
-            let backup_path = Path::new(&backup_path);
-            fs::rename(current_path, backup_path)
-                .expect("main: error on backing up search index directory for recreating");
-            if UnmanagedSearcher::create(&CONFIG.search_index, &CONFIG.search_tokenizers).is_ok() {
-                if fs::remove_dir_all(backup_path).is_err() {
-                    eprintln!(
-                        "error on removing backup directory: {}. it remains",
-                        backup_path.display()
-                    );
-                }
-            } else {
-                panic!("main: error on recreating search index in new index format. remove search index and run `plm search init` manually");
-            }
-        }
-        open_searcher = UnmanagedSearcher::open(&CONFIG.search_index, &CONFIG.search_tokenizers);
-    }
-    #[allow(clippy::match_wild_err_arm)]
-    let searcher = match open_searcher {
-        Err(Error::Search(e)) => match e {
-            SearcherError::WriteLockAcquisitionError => panic!(
-                r#"
-Your search index is locked. Plume can't start. To fix this issue
-make sure no other Plume instance is started, and run:
 
-    plm search unlock
-
-Then try to restart Plume.
-"#
-            ),
-            SearcherError::IndexOpeningError => panic!(
-                r#"
-Plume was unable to open the search index. If you created the index
-before, make sure to run Plume in the same directory it was created in, or
-to set SEARCH_INDEX accordingly. If you did not yet create the search
-index, run this command:
-
-    plm search init
-
-Then try to restart Plume
-"#
-            ),
-            e => Err(e).unwrap(),
-        },
-        Err(_) => panic!("Unexpected error while opening search index"),
-        Ok(s) => Arc::new(s),
-    };
-
+    let searcher = Searcher::new(dbpool.clone());
     let commiter = searcher.clone();
     workpool.execute_with_fixed_delay(
         Duration::from_secs(5),

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ Then try to restart Plume.
     }
     let workpool = ScheduledThreadPool::with_name("worker {}", num_cpus::get());
 
-    let searcher = Searcher::new(dbpool.clone());
+    let searcher = Arc::new(Searcher::new(dbpool.clone()));
     let commiter = searcher.clone();
     workpool.execute_with_fixed_delay(
         Duration::from_secs(5),

--- a/src/routes/search.rs
+++ b/src/routes/search.rs
@@ -51,7 +51,6 @@ macro_rules! param_to_query {
 
 #[get("/search?<query..>")]
 pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
-    let conn = &*rockets.conn;
     let query = query.map(Form::into_inner).unwrap_or_default();
     let page = query.page.unwrap_or_default();
     let mut parsed_query =
@@ -72,7 +71,7 @@ pub fn search(query: Option<Form<SearchQuery>>, rockets: PlumeRocket) -> Ructe {
     } else {
         let res = rockets
             .searcher
-            .search_document(&conn, parsed_query, page.limits());
+            .search_document(parsed_query, page.limits());
         let next_page = if res.is_empty() { 0 } else { page.0 + 1 };
         render!(search::result(
             &rockets.to_context(),


### PR DESCRIPTION
This PR is another attempt at fixing https://git.joinplu.me/Plume/Plume/issues/799

Instead of relying on a separate actor model, as described, we make use of the fact that DbPool is an `Arc`, and can be arbitrarily cloned, so we add it to `Searcher`. Further more, and `db_pool.get()` *acts* like sending a message to an Actor: if there are enough connections, the Pool gives us one, if not, tough luck!

this way, we don't need to pass along a conn into the searcher functions.
This should make splitting PlumeRocket up into its components a little easier. 