### PR TITLE
Fix displaying not found page when submitting a duplicated blocklist email

### DIFF
--- a/src/routes/instance.rs
+++ b/src/routes/instance.rs
@@ -210,11 +210,19 @@ pub fn add_email_blocklist(
     form: LenientForm<NewBlocklistedEmail>,
     rockets: PlumeRocket,
 ) -> Result<Flash<Redirect>, ErrorPage> {
-    BlocklistedEmail::insert(&*rockets.conn, form.0)?;
-    Ok(Flash::success(
-        Redirect::to(uri!(admin_email_blocklist: page = None)),
-        i18n!(rockets.intl.catalog, "Email Blocked"),
-    ))
+    let result = BlocklistedEmail::insert(&*rockets.conn, form.0);
+
+    if let Err(Error::Db(_)) = result {
+        Ok(Flash::error(
+            Redirect::to(uri!(admin_email_blocklist: page = None)),
+            i18n!(rockets.intl.catalog, "Email already blocked")
+        ))
+    } else {
+        Ok(Flash::success(
+            Redirect::to(uri!(admin_email_blocklist: page = None)),
+            i18n!(rockets.intl.catalog, "Email Blocked"),
+        ))
+    }
 }
 #[get("/admin/emails?<page>")]
 pub fn admin_email_blocklist(


### PR DESCRIPTION
This PR addresses issue #754. I'm still new to Rust and even newer to Plume, but I thought this approach made sense. The alternative I thought of was to leverage the `BlocklistedEmail::matches_blocklist` function, but I thought that approach is unreasonable because it requires loading the entire blocklisted_emails table.