### PR TITLE
Recreate the fix that worked for #75 to close iOS menu with Javascript

### DIFF
--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -159,7 +159,7 @@ body > header {
 
     animation-duration: 0.2s menuOpening;
 
-    &::before {
+    &::before, #content.show::before {
       content: "";
       position: absolute;
       transform: skewX(-10deg);

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-    align-content: center;
-    justify-content: space-between;
+     align-content: center;
+     justify-content: space-between;
   }
 
   nav#menu {
@@ -49,30 +49,30 @@ body > header {
       
     }
     a {
-      display: flex;
-      align-items: center;
-      position: relative;
-      align-self: stretch;
-      margin: 0;
-      padding: 0 2em;
-      font-size: 1em;
+       display: flex;
+       align-items: center;
+       position: relative;
+       align-self: stretch;
+       margin: 0;
+       padding: 0 2em;
+       font-size: 1em;
 
-      i { font-size: 1.2em; }
+       i { font-size: 1.2em; }
 
-      &.title {
-        margin: 0;
-        text-align: center;
-        padding: 0.5em 1em;
-        font-size: 1.75em;
+       &.title {
+         margin: 0;
+         text-align: center;
+         padding: 0.5em 1em;
+         font-size: 1.75em;
 
-        img {
-          height: 1.75em;
-          width: 1.75em;
-        }
+         img {
+           height: 1.75em;
+           width: 1.75em;
+         }
 
-        p {
-          margin: 0;
-          padding-left: 0.5em;
+         p {
+           margin: 0;
+           padding-left: 0.5em;
         }
       }
     }

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-   	align-content: center;
-   	justify-content: space-between;
+    align-content: center;
+    justify-content: space-between;
   }
 
   nav#menu {
@@ -19,44 +19,44 @@ body > header {
 
     a {
       transform: skewX(15deg);
-     	display: flex;
-     	flex-direction: column;
-     	align-items: center;
-     	justify-content: center;
-     	width: 1.4em;
-     	height: 1.4em;
-     	margin: 0;
-     	padding: 0;
-     	color: $gray;
-     	font-size: 1.33em;
-   	}
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      width: 1.4em;
+      height: 1.4em;
+      margin: 0;
+      padding: 0;
+      color: $gray;
+      font-size: 1.33em;
+    }
   }
 
   nav {
     display: flex;
-   	flex-direction: row;
-   	align-items: center;
+    flex-direction: row;
+    align-items: center;
 
-   	hr {
-     	height: 100%;
-     	width: 0.2em;
-     	background: $primary;
-     	border: none;
-     	transform: skewX(-15deg);
+    hr {
+      height: 100%;
+      width: 0.2em;
+      background: $primary;
+      border: none;
+      transform: skewX(-15deg);
     }
     a {
-     	display: flex;
-     	align-items: center;
-     	position: relative;
-     	align-self: stretch;
-     	margin: 0;
-     	padding: 0 2em;
-     	font-size: 1em;
+      display: flex;
+      align-items: center;
+      position: relative;
+      align-self: stretch;
+      margin: 0;
+      padding: 0 2em;
+      font-size: 1em;
 
-     	i { font-size: 1.2em; }
+      i { font-size: 1.2em; }
 
-     	&.title {
-     	  margin: 0;
+      &.title {
+        margin: 0;
         text-align: center;
         padding: 0.5em 1em;
         font-size: 1.75em;
@@ -70,7 +70,7 @@ body > header {
           margin: 0;
           padding-left: 0.5em;
         }
-     	}
+      }
     }
   }
 }
@@ -158,10 +158,11 @@ body > header {
 
     animation-duration: 0.2s menuOpening;
 
-    &::before, #content.show::before {
+    &::before {
       content: "";
       position: absolute;
       transform: skewX(-10deg);
+      -webkit-transform: skewX(-10deg);
       top: 0;
       left: -20%;
       width: 100%;
@@ -205,38 +206,39 @@ body > header {
 
 /* Only enable label animations on large screens */
 @media screen and (min-width: 600px) {
- 	header nav a {
- 	  i {
-   		transition: all 0.2s ease;
-   		margin: 0;
-   	}
-
-   	.mobile-label {
-   		transition: all 0.2s ease;
+  header nav a {
+    i {
+      transition: all 0.2s ease;
       -webkit-transition: all 0.2s ease;
-   		display: block;
-   		position: absolute;
-   		left: 50%;
-   		transform: translate(-50%, 0);
-      -webkit-transform: translate(-50%, 0);
-   		transform: translateZ(0);
-   		-webkit-transform: none !important;
-   		opacity: 0;
-   		font-size: 0.9em;
-   		white-space: nowrap;
-   	}
-
-   	img + .mobile-label { display: none; }
-
-   	&:hover {
-   	  i { margin-bottom: 0.75em; }
-   	  .mobile-label {
-   	    opacity: 1;
-     		transform: translate(-50%, 80%);
-     		-webkit-transform: translate(-50%, 80%);
-   		}
+      margin: 0;
     }
- 	}
+
+    .mobile-label {
+      transition: all 0.2s ease;
+      -webkit-transition: all 0.2s ease;
+      display: block;
+      position: absolute;
+      left: 50%;
+      transform: translate(-50%, 0);
+      -webkit-transform: translate(-50%, 0);
+      transform: translateZ(0);
+      -webkit-transform: none !important;
+      opacity: 0;
+      font-size: 0.9em;
+      white-space: nowrap;
+    }
+
+    img + .mobile-label { display: none; }
+
+    &:hover {
+      i { margin-bottom: 0.75em; }
+      .mobile-label {
+        opacity: 1;
+       transform: translate(-50%, 80%);
+       -webkit-transform: translate(-50%, 80%);
+     }
+    }
+  }
 }
 
 // Small screens
@@ -300,6 +302,7 @@ body > header {
       content: "";
       position: absolute;
       transform: skewX(-10deg);
+      -webkit-transform: skewX(-10deg);
       top: 0;
       left: -20%;
       width: 100%;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-    	align-content: center;
-   	  justify-content: space-between;
+   	align-content: center;
+   	justify-content: space-between;
   }
 
   nav#menu {

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -49,30 +49,30 @@ body > header {
       
     }
     a {
-       display: flex;
-       align-items: center;
-       position: relative;
-       align-self: stretch;
-       margin: 0;
-       padding: 0 2em;
-       font-size: 1em;
+    display: flex;
+    align-items: center;
+    position: relative;
+    align-self: stretch;
+    margin: 0;
+    padding: 0 2em;
+    font-size: 1em;
 
-       i { font-size: 1.2em; }
+    i { font-size: 1.2em; }
 
-       &.title {
-         margin: 0;
-         text-align: center;
-         padding: 0.5em 1em;
-         font-size: 1.75em;
+    &.title {
+      margin: 0;
+      text-align: center;
+      padding: 0.5em 1em;
+      font-size: 1.75em;
 
-         img {
-           height: 1.75em;
-           width: 1.75em;
-         }
+      img {
+        height: 1.75em;
+        width: 1.75em;
+      }
 
-         p {
-           margin: 0;
-           padding-left: 0.5em;
+      p {
+        margin: 0;
+        padding-left: 0.5em;
         }
       }
     }
@@ -210,26 +210,26 @@ body > header {
 
 /* Only enable label animations on large screens */
 @media screen and (min-width: 600px) {
-  header nav a {
-    i {
-      transition: all 0.2s ease;
-      -webkit-transition: all 0.2s ease;
-      margin: 0;
-    }
+header nav a {
+  i {
+    transition: all 0.2s ease;
+    -webkit-transition: all 0.2s ease;
+    margin: 0;
+  }
 
-    .mobile-label {
-      transition: all 0.2s ease;
-      -webkit-transition: all 0.2s ease;
-      display: block;
-      position: absolute;
-      left: 50%;
-      transform: translate(-50%, 0);
-      -webkit-transform: translate(-50%, 0);
-      transform: translateZ(0);
-      -webkit-transform: none !important;
-      opacity: 0;
-      font-size: 0.9em;
-      white-space: nowrap;
+  .mobile-label {
+    transition: all 0.2s ease;
+    -webkit-transition: all 0.2s ease;
+    display: block;
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    -webkit-transform: translate(-50%, 0);
+    transform: translateZ(0);
+    -webkit-transform: none !important;
+    opacity: 0;
+    font-size: 0.9em;
+    white-space: nowrap;
     }
 
     img + .mobile-label { display: none; }

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -9,9 +9,10 @@ body > header {
 
   nav#menu {
     position: relative;
-    display: block;
+    display: none;
     appearance: none;
     transform: skewX(-15deg);
+    -webkit-transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
     background: $primary;
@@ -19,6 +20,7 @@ body > header {
 
     a {
       transform: skewX(15deg);
+      -webkit-transform: skewX(15deg);
      	display: flex;
      	flex-direction: column;
      	align-items: center;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -158,7 +158,7 @@ body > header {
     height: 100%;
     box-sizing: border-box;
 
-    animation: 0.2s menuOpening;
+    animation-duration: 0.2s menuOpening;
 
     &::before, #content.show::before {
       content: "";
@@ -215,10 +215,12 @@ body > header {
 
    	.mobile-label {
    		transition: all 0.2s ease;
+      -webkit-transition: all 0.2s ease;
    		display: block;
    		position: absolute;
    		left: 50%;
    		transform: translate(-50%, 0);
+      -webkit-transform: translate(-50%, 0);
    		transform: translateZ(0);
    		-webkit-transform: none !important;
    		opacity: 0;
@@ -294,7 +296,7 @@ body > header {
     height: 100%;
     box-sizing: border-box;
 
-    animation: 0.2s menuOpening;
+    animation-duration: 0.2s menuOpening;
 
     &::before {
       content: "";

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-     align-content: center;
-     justify-content: space-between;
+      align-content: center;
+      justify-content: space-between;
   }
 
   nav#menu {

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -74,7 +74,7 @@ body > header {
         margin: 0;
         padding-left: 0.5em;
         }
-      }
+     	}
     }
   }
 }
@@ -242,7 +242,7 @@ header nav a {
        -webkit-transform: translate(-50%, 80%);
      }
     }
-  }
+ 	}
 }
 
 // Small screens

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -9,7 +9,7 @@ body > header {
 
   nav#menu {
     position: relative;
-    display: none;
+    display: block;
     appearance: none;
     transform: skewX(-15deg);
     left: -1em;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -212,9 +212,9 @@ body > header {
 @media screen and (min-width: 600px) {
 header nav a {
   i {
-    transition: all 0.2s ease;
-    -webkit-transition: all 0.2s ease;
-    margin: 0;
+   		transition: all 0.2s ease;
+   		-webkit-transition: all 0.2s ease;
+   		margin: 0;
   }
 
   .mobile-label {

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -19,6 +19,7 @@ body > header {
 
     a {
       transform: skewX(15deg);
+      -webkit-transform: skewX(15deg);
       display: flex;
       flex-direction: column;
       align-items: center;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -12,7 +12,6 @@ body > header {
     display: none;
     appearance: none;
     transform: skewX(-15deg);
-    -webkit-transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
     background: $primary;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -12,6 +12,7 @@ body > header {
     display: none;
     appearance: none;
     transform: skewX(-15deg);
+    -webkit-transform: skewX(-15deg);
     left: -1em;
     padding: 1em 1em 1em 2em;
     background: $primary;
@@ -44,6 +45,8 @@ body > header {
       background: $primary;
       border: none;
       transform: skewX(-15deg);
+      -webkit-transform: skewX(-15deg);
+      
     }
     a {
       display: flex;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -4,7 +4,7 @@ body > header {
   #content {
     display: flex;
     	align-content: center;
-    	justify-content: space-between;
+   	  justify-content: space-between;
   }
 
   nav#menu {

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -158,7 +158,7 @@ body > header {
 
     animation: 0.2s menuOpening;
 
-    &::before {
+    &::before, #content.show::before {
       content: "";
       position: absolute;
       transform: skewX(-10deg);

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-      align-content: center;
-      justify-content: space-between;
+    	align-content: center;
+    	justify-content: space-between;
   }
 
   nav#menu {

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -20,7 +20,6 @@ body > header {
 
     a {
       transform: skewX(15deg);
-      -webkit-transform: skewX(15deg);
      	display: flex;
      	flex-direction: column;
      	align-items: center;

--- a/assets/themes/default/_header.scss
+++ b/assets/themes/default/_header.scss
@@ -3,8 +3,8 @@ body > header {
 
   #content {
     display: flex;
-      align-content: center;
-      justify-content: space-between;
+     align-content: center;
+     justify-content: space-between;
   }
 
   nav#menu {

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,9 +1,10 @@
-
-
-
-
-    
-
 const button = document.getElementById('menu')
+const menu = document.getElementById('content')
 
-    
+button.addEventListener('click', () => {
+  menu.classList.add('show')
+})
+
+menu.addEventListener('click', () => {
+  menu.classList.remove('show')
+})

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,0 +1,9 @@
+
+
+
+
+    
+
+const button = document.getElementById('menu')
+
+    

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -97,5 +97,6 @@
             </div>
         </footer>
         <script src="@uri!(plume_static_files: file = "plume-front.js", build_id = CACHE_NAME)"></script>
+        <script src="/js/menu.js"></script>
     </body>
 </html>

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -97,6 +97,6 @@
             </div>
         </footer>
         <script src="@uri!(plume_static_files: file = "plume-front.js", build_id = CACHE_NAME)"></script>
-        <script src="/js/menu.js"></script>
+        <script type="text/javascript" src="/js/menu.js"></script>
     </body>
 </html>


### PR DESCRIPTION
This was the original code that worked fine on iOS to close the menu back in Plume 0.2.0, but it requires the reintroduction of a small piece of Javascript.

Should finally close #842.
